### PR TITLE
refactor: process_media コマンドを ProcessOptions 受けに統一 (#8)

### DIFF
--- a/LINT_SETUP.md
+++ b/LINT_SETUP.md
@@ -167,7 +167,6 @@ git commit --no-verify -m "message"
 
 - `create_photo_to_group_map` 関数が未使用
 - `duration_ms` フィールドが未使用
-- `process_media` 関数の引数が8個（推奨7個以下）
 
 ### TypeScript
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,7 +29,10 @@ fn scan_media(
 // 以前はフィールドをフラットな引数に展開して即再構築していたが、option セットの定義が
 // 二重化し clippy::too_many_arguments を抑止する羽目になっていた。構造体で受けることで
 // 正本を 1 箇所に集約し、抑止属性を不要にする（#8）。`ProcessOptions` は Serialize/Deserialize
-// 済みのため wire 契約は `{ inputDir, outputDir, options: { ... } }` となる。
+// 済みのため wire 契約は `{ inputDir, outputDir, options: { ... } }`。トップレベル引数は Tauri が
+// camelCase 化するが、ネストした `options` の内部キーは ProcessOptions の serde 名そのまま＝
+// snake_case（`backup_dir` / `include_videos` / `timezone_offset` / `cleanup_temp` /
+// `auto_correct_orientation`）で渡す必要がある（rename_all 無し。photo_core::tests で固定済み）。
 #[tauri::command]
 fn process_media(
     input_dir: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,31 +24,20 @@ fn scan_media(
 }
 
 /// メディアファイルをリネームして出力ディレクトリに整理（再スキャンあり版、後方互換用）
-// Tauri コマンドの公開引数がそのまま並ぶため引数が多い。API 互換のため統合せず lint のみ抑止する。
-#[allow(clippy::too_many_arguments)]
+//
+// 処理オプションは `ProcessOptions` を正本とし、コマンド境界でも構造体のまま受け取る。
+// 以前はフィールドをフラットな引数に展開して即再構築していたが、option セットの定義が
+// 二重化し clippy::too_many_arguments を抑止する羽目になっていた。構造体で受けることで
+// 正本を 1 箇所に集約し、抑止属性を不要にする（#8）。`ProcessOptions` は Serialize/Deserialize
+// 済みのため wire 契約は `{ inputDir, outputDir, options: { ... } }` となる。
 #[tauri::command]
 fn process_media(
     input_dir: String,
     output_dir: String,
-    backup_dir: Option<String>,
-    include_videos: bool,
-    parallel: bool,
-    timezone_offset: Option<i32>,
-    cleanup_temp: bool,
-    auto_correct_orientation: bool,
+    options: ProcessOptions,
 ) -> Result<ProcessResult, String> {
     let input_path = PathBuf::from(input_dir);
     let output_path = PathBuf::from(output_dir);
-    let backup_path = backup_dir.map(PathBuf::from);
-
-    let options = ProcessOptions {
-        parallel,
-        include_videos,
-        backup_dir: backup_path,
-        timezone_offset,
-        cleanup_temp,
-        auto_correct_orientation,
-    };
 
     photo_core::process_media(&input_path, &output_path, &options).map_err(|e| e.to_string())
 }

--- a/src-tauri/src/photo_core/mod.rs
+++ b/src-tauri/src/photo_core/mod.rs
@@ -755,4 +755,37 @@ mod tests {
             "MediaInfo の top-level キーは 23 個のはず"
         );
     }
+
+    /// フロントエンド契約の機械検証:
+    /// `process_media` コマンド（lib.rs）は `options: ProcessOptions` を構造体のまま受け取る。
+    /// ProcessOptions には `#[serde(rename_all = ...)]` が無いため、wire 上のキーは snake_case。
+    /// Tauri がトップレベル引数を camelCase 化するのは `input_dir`→`inputDir` 等だけで、
+    /// ネストした `options` の内部キーには適用されない。将来このコマンドを invoke で配線する際は
+    /// `options: { backup_dir, include_videos, ... }` と snake_case で渡す必要がある。
+    /// rename_all を足すと黙ってこの契約が変わるので、それを CI で射抜く。
+    #[test]
+    fn process_options_wire_keys_are_snake_case() {
+        let value =
+            serde_json::to_value(ProcessOptions::default()).expect("serialize ProcessOptions");
+        let obj = value
+            .as_object()
+            .expect("ProcessOptions must serialize to a JSON object");
+
+        let actual: BTreeSet<&str> = obj.keys().map(|k| k.as_str()).collect();
+        let expected: BTreeSet<&str> = [
+            "parallel",
+            "backup_dir",
+            "include_videos",
+            "timezone_offset",
+            "cleanup_temp",
+            "auto_correct_orientation",
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(
+            actual, expected,
+            "ProcessOptions の JSON キーが snake_case 契約と一致しません（rename_all を足すとフロント配線が壊れる）"
+        );
+    }
 }


### PR DESCRIPTION
## 概要

`process_media` Tauri コマンドの 8 引数フラット展開を `options: ProcessOptions` 受けに統一し、`#[allow(clippy::too_many_arguments)]` を撤去する。Closes #8。

## 背景

clippy `too_many_arguments` が黙らされていた本質は「引数が多い」ことではなく、**option セットの定義が2箇所に重複している**こと:

```rust
// Before: 6つのフィールドを引数で受け取り、2行下で同じ6つを ProcessOptions に再構築
fn process_media(input_dir, output_dir, backup_dir, include_videos, parallel,
                 timezone_offset, cleanup_temp, auto_correct_orientation) {
    let options = ProcessOptions { parallel, include_videos, backup_dir, ... };
    ...
}
```

`ProcessOptions` は既に `Serialize/Deserialize` 済みでワイヤを渡れるため、コマンド境界でも構造体のまま受け取れば正本が1箇所に集約され、抑止属性は「抑制」ではなく「不要になって消える」。

```rust
// After
fn process_media(input_dir: String, output_dir: String, options: ProcessOptions) -> ...
```

## スコープ判断

- **対象 = `process_media` のみ**。フロントの `invoke` サイトは0件（"後方互換用" 通り未使用）なので挙動・UI 無影響。wire 契約は `{ inputDir, outputDir, options: {...} }` に変わるが現行の呼び出し元は無い。
- **`process_media_with_settings` は対象外**。`timezone_offset=None` / `auto_correct_orientation=false` を意図的に握り潰す**狭い契約**で、引数6個で clippy 警告も出ていない。full `ProcessOptions` を通すと握り潰すべきフィールドが露出して挙動が変わるため触らない。

## 検証

- `cargo test` … 28 passed / 0 failed（characterization 不変）
- `cargo clippy --all-targets -- -D warnings` … exit 0（`#[allow]` 撤去後も警告ゼロ）
- `LINT_SETUP.md` の「process_media 関数の引数が8個」という stale な既知警告メモを削除