### PR TITLE
fix: リトライを失敗ファイルのみ対象にする (#6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Build frontend (tsc + vite)
         run: npm run build
 
+      - name: Frontend tests (vitest)
+        run: npm test
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,8 @@
         "prettier-plugin-tailwindcss": "^0.7.1",
         "tailwindcss": "^4.1.16",
         "typescript": "~5.8.3",
-        "vite": "^7.0.4"
+        "vite": "^7.0.4",
+        "vitest": "^3.2.6"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2052,6 +2053,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2340,6 +2359,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2570,6 +2704,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2703,6 +2847,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -2784,6 +2938,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2799,6 +2970,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cli-cursor": {
@@ -2977,6 +3158,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -3218,6 +3409,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3649,6 +3847,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3665,6 +3873,16 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5110,6 +5328,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5469,6 +5694,23 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6079,6 +6321,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6131,6 +6380,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -6300,6 +6563,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6347,6 +6630,13 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -6372,6 +6662,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6627,6 +6947,109 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6730,6 +7153,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "format:rust": "cargo fmt --manifest-path src-tauri/Cargo.toml",
     "format:rust:check": "cargo fmt --manifest-path src-tauri/Cargo.toml -- --check",
     "lint-format:rust": "cargo fmt --manifest-path src-tauri/Cargo.toml && cargo clippy --manifest-path src-tauri/Cargo.toml",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test": "vitest run"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
@@ -58,6 +59,7 @@
     "prettier-plugin-tailwindcss": "^0.7.1",
     "tailwindcss": "^4.1.16",
     "typescript": "~5.8.3",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^3.2.6"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import {
 import './App.css';
 import { MOCK_ENABLED, mockMediaList, mockProcessResult } from './mock-data';
 import type { MediaInfo, ProcessResult } from './types';
+import { mergeProcessResults, selectRetryTargets } from './lib/processResults';
 import { MainLayout } from './components/MainLayout';
 import { useMediaTableColumns } from './hooks/useMediaTableColumns';
 import { getStorageValue, saveStorage } from './storage';
@@ -216,7 +217,9 @@ function App() {
   };
 
   // 処理実行
-  const processMedia = async () => {
+  // itemsToProcess を渡すとそのサブセットのみ処理する（リトライ時に失敗ファイルだけを対象にする）。
+  // 省略時は全件処理（初回実行）。
+  const processMedia = async (itemsToProcess?: MediaInfo[]) => {
     if (!inputDir || !outputDir) {
       alert('Please select both input and output directories');
       return;
@@ -224,6 +227,11 @@ function App() {
 
     if (mediaList.length === 0) {
       alert('No media files to process. Please scan first.');
+      return;
+    }
+
+    const targets = itemsToProcess ?? mediaList;
+    if (targets.length === 0) {
       return;
     }
 
@@ -266,7 +274,7 @@ function App() {
 
     try {
       const result = await invoke<ProcessResult>('process_media_with_settings', {
-        mediaList,
+        mediaList: targets,
         outputDir,
         backupDir: null,
         parallel: true,
@@ -276,24 +284,9 @@ function App() {
 
       setProcessResult(result);
 
-      // 処理結果を反映
-      // Rust から返る original_path はプラットフォーム依存のセパレータを持つ場合があるため、
-      // スラッシュ統一後に比較する（Windowsでの \\ vs / 問題を回避）
-      const normalizeForCompare = (p: string) => p.replace(/\\/g, '/');
-      const updatedMedia = mediaList.map((item) => {
-        const normalizedItem = normalizeForCompare(item.original_path);
-        const processed = result.media.find(
-          (m: MediaInfo) => normalizeForCompare(m.original_path) === normalizedItem
-        );
-        return {
-          ...item,
-          progress: 100,
-          status: processed?.new_path ? ('completed' as const) : ('error' as const),
-          new_path: processed?.new_path || '',
-        };
-      });
-
-      setMediaList(updatedMedia);
+      // 処理結果を反映。今回処理した targets のみ更新し、対象外（完了済みなど）は
+      // 据え置く（リトライで完了済みを再処理・誤 error 化しない）。
+      setMediaList((prev) => mergeProcessResults(prev, targets, result.media));
     } catch (error) {
       console.error('Process error:', error);
       alert(`Process error: ${error}`);
@@ -304,7 +297,7 @@ function App() {
 
   // エラーファイルのみ再処理
   const retryFailedFiles = async () => {
-    const errorFiles = mediaList.filter((item) => item.status === 'error');
+    const errorFiles = selectRetryTargets(mediaList);
 
     if (errorFiles.length === 0) {
       alert('No failed files to retry');
@@ -327,8 +320,8 @@ function App() {
       )
     );
 
-    // 再処理実行
-    await processMedia();
+    // 失敗ファイルのみを再処理（完了済みは対象外）
+    await processMedia(errorFiles);
   };
 
   // Use custom hook for table columns

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -273,6 +273,8 @@ function App() {
     setProcessResult(null);
 
     try {
+      // backend は渡した media_list だけを処理し、各項目の status は見ない。
+      // よってリトライ時は失敗ファイルのみを targets に入れれば、完了済みは再処理されない。
       const result = await invoke<ProcessResult>('process_media_with_settings', {
         mediaList: targets,
         outputDir,

--- a/src/lib/processResults.test.ts
+++ b/src/lib/processResults.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import type { MediaInfo, LogEntry } from '../types';
+import { mergeProcessResults, normalizePathForCompare, selectRetryTargets } from './processResults';
+
+const log = (message: string): LogEntry => ({
+  timestamp: '2026-01-01T00:00:00Z',
+  level: 'Info',
+  message,
+});
+
+/** テスト用に MediaInfo を最小フィールドで組み立てる。 */
+function media(path: string, over: Partial<MediaInfo> = {}): MediaInfo {
+  return {
+    original_path: path,
+    file_name: path.split(/[\\/]/).pop() ?? path,
+    media_type: 'Photo',
+    date_taken: null,
+    subsec_time: null,
+    timezone: null,
+    exif_date: null,
+    filename_date: null,
+    file_created_date: null,
+    file_modified_date: null,
+    new_name: '',
+    new_path: '',
+    file_size: 0,
+    burst_group_id: null,
+    burst_index: null,
+    date_source: 'None',
+    exif_orientation: null,
+    rotation_applied: false,
+    width: null,
+    height: null,
+    logs: [],
+    ...over,
+  };
+}
+
+describe('normalizePathForCompare', () => {
+  it('Windows の \\ を / に統一する', () => {
+    expect(normalizePathForCompare('C:\\photos\\a.jpg')).toBe('C:/photos/a.jpg');
+  });
+});
+
+describe('selectRetryTargets', () => {
+  it('status==="error" の項目だけ返す', () => {
+    const list = [
+      media('/a.jpg', { status: 'completed' }),
+      media('/b.jpg', { status: 'error' }),
+      media('/c.jpg', { status: 'pending' }),
+      media('/d.jpg', { status: 'error' }),
+    ];
+    expect(selectRetryTargets(list).map((m) => m.original_path)).toEqual(['/b.jpg', '/d.jpg']);
+  });
+});
+
+describe('mergeProcessResults', () => {
+  it('対象外（完了済み）の項目は一切触らない＝リトライで再処理・誤error化しない', () => {
+    const completed = media('/done.jpg', {
+      status: 'completed',
+      new_path: '/out/2026/done.jpg',
+      logs: [log('done earlier')],
+    });
+    const failed = media('/fail.jpg', { status: 'pending' });
+    const full = [completed, failed];
+
+    // リトライ: 失敗ファイルのみを対象に送る
+    const targets = [failed];
+    // バックエンドは対象分のみ返す（完了済みは含まれない）
+    const resultMedia = [
+      media('/fail.jpg', { new_path: '/out/2026/fail.jpg', logs: [log('retried ok')] }),
+    ];
+
+    const merged = mergeProcessResults(full, targets, resultMedia);
+
+    // 完了済みは参照ごと不変
+    expect(merged[0]).toBe(completed);
+    expect(merged[0].status).toBe('completed');
+    expect(merged[0].new_path).toBe('/out/2026/done.jpg');
+
+    // 失敗ファイルは完了に更新され、ログも取り込まれる
+    expect(merged[1].status).toBe('completed');
+    expect(merged[1].new_path).toBe('/out/2026/fail.jpg');
+    expect(merged[1].logs.map((l) => l.message)).toContain('retried ok');
+  });
+
+  it('対象だが結果に無い項目は error 扱い', () => {
+    const item = media('/x.jpg', { status: 'pending' });
+    const merged = mergeProcessResults([item], [item], []);
+    expect(merged[0].status).toBe('error');
+    expect(merged[0].new_path).toBe('');
+  });
+
+  it('プラットフォーム差のあるパスでも一致させる', () => {
+    const item = media('C:\\photos\\x.jpg', { status: 'pending' });
+    const resultMedia = [media('C:/photos/x.jpg', { new_path: 'C:/out/x.jpg' })];
+    const merged = mergeProcessResults([item], [item], resultMedia);
+    expect(merged[0].status).toBe('completed');
+    expect(merged[0].new_path).toBe('C:/out/x.jpg');
+  });
+});

--- a/src/lib/processResults.test.ts
+++ b/src/lib/processResults.test.ts
@@ -84,11 +84,33 @@ describe('mergeProcessResults', () => {
     expect(merged[1].logs.map((l) => l.message)).toContain('retried ok');
   });
 
-  it('対象だが結果に無い項目は error 扱い', () => {
-    const item = media('/x.jpg', { status: 'pending' });
+  it('対象だが結果に無い項目は error 扱い・progress は 0', () => {
+    const item = media('/x.jpg', { status: 'pending', progress: 0 });
     const merged = mergeProcessResults([item], [item], []);
     expect(merged[0].status).toBe('error');
     expect(merged[0].new_path).toBe('');
+    expect(merged[0].progress).toBe(0); // 失敗なのに100%にしない
+  });
+
+  it('targets が空なら全項目を参照ごと据え置く（初回スキャン直後など）', () => {
+    const a = media('/a.jpg', { status: 'completed', new_path: '/out/a.jpg' });
+    const b = media('/b.jpg', { status: 'error' });
+    const merged = mergeProcessResults([a, b], [], []);
+    expect(merged[0]).toBe(a);
+    expect(merged[1]).toBe(b);
+  });
+
+  it('no_change の項目は targets 外なら触らない（誤 error 化しない）', () => {
+    const noChange = media('/keep.jpg', { status: 'no_change', new_path: '' });
+    const failed = media('/fail.jpg', { status: 'pending' });
+    const merged = mergeProcessResults(
+      [noChange, failed],
+      [failed],
+      [media('/fail.jpg', { new_path: '/out/fail.jpg' })]
+    );
+    expect(merged[0]).toBe(noChange); // no_change は据え置き
+    expect(merged[0].status).toBe('no_change');
+    expect(merged[1].status).toBe('completed');
   });
 
   it('プラットフォーム差のあるパスでも一致させる', () => {

--- a/src/lib/processResults.ts
+++ b/src/lib/processResults.ts
@@ -13,11 +13,18 @@ export function normalizePathForCompare(path: string): string {
  *
  * `targets` は今回 `process_media_with_settings` に渡したサブセット（初回は全件、
  * リトライ時は失敗ファイルのみ）。**対象に含まれない項目（前回完了済みなど）は一切
- * 触らず据え置く**ことで、リトライが完了済みファイルを再処理扱いにする/誤って error
- * 化する不具合（#6）を防ぐ。
+ * 触らず（同一参照のまま）据え置く**ことで、リトライが完了済みファイルを再処理扱いに
+ * する/誤って error 化する不具合（#6）を防ぐ。
  *
- * 対象項目は結果（`resultMedia`）から status / new_path / logs を取り込む。結果に
- * 見つからなければ error 扱いにする。
+ * 対象項目は結果（`resultMedia`）から new_path / logs を取り込む。成否は **new_path の
+ * 有無**で判定する（現行バックエンドは成功時のみ new_path をセットし、失敗は early-return。
+ * `status` フィールドは返さない）。
+ *
+ * 前提:
+ * - `targets` は未処理/失敗の項目に限る（`selectRetryTargets` 経由なら error のみ）。
+ *   `no_change`（移動不要で正常終了）は現行バックエンドに存在せず targets にも入らないが、
+ *   将来導入する場合はこの new_path ベース判定が誤 error 化し得るので注意。
+ * - `original_path` は scan が一意に列挙するためキーとして衝突しない。
  */
 export function mergeProcessResults(
   fullList: MediaInfo[],
@@ -34,10 +41,12 @@ export function mergeProcessResults(
     }
 
     const processed = resultMedia.find((m) => normalizePathForCompare(m.original_path) === key);
+    const succeeded = Boolean(processed?.new_path);
     return {
       ...item,
-      progress: 100,
-      status: processed?.new_path ? ('completed' as const) : ('error' as const),
+      // 失敗時に progress=100 とすると「失敗なのに100%」になるため成否で出し分ける
+      progress: succeeded ? 100 : 0,
+      status: succeeded ? ('completed' as const) : ('error' as const),
       new_path: processed?.new_path ?? '',
       // 結果のログを取り込む（リトライ対象の処理ログを LogViewer で確認できる）
       logs: processed?.logs ?? item.logs,

--- a/src/lib/processResults.ts
+++ b/src/lib/processResults.ts
@@ -1,0 +1,53 @@
+import type { MediaInfo } from '../types';
+
+/**
+ * プラットフォーム依存のパス区切り（Windows の `\\` と POSIX の `/`）を吸収して
+ * original_path を比較するための正規化。
+ */
+export function normalizePathForCompare(path: string): string {
+  return path.replace(/\\/g, '/');
+}
+
+/**
+ * バックエンドの処理結果を全リストにマージする。
+ *
+ * `targets` は今回 `process_media_with_settings` に渡したサブセット（初回は全件、
+ * リトライ時は失敗ファイルのみ）。**対象に含まれない項目（前回完了済みなど）は一切
+ * 触らず据え置く**ことで、リトライが完了済みファイルを再処理扱いにする/誤って error
+ * 化する不具合（#6）を防ぐ。
+ *
+ * 対象項目は結果（`resultMedia`）から status / new_path / logs を取り込む。結果に
+ * 見つからなければ error 扱いにする。
+ */
+export function mergeProcessResults(
+  fullList: MediaInfo[],
+  targets: MediaInfo[],
+  resultMedia: MediaInfo[]
+): MediaInfo[] {
+  const targetPaths = new Set(targets.map((t) => normalizePathForCompare(t.original_path)));
+
+  return fullList.map((item) => {
+    const key = normalizePathForCompare(item.original_path);
+    if (!targetPaths.has(key)) {
+      // 今回処理していない項目は不変（完了済みを再処理・誤判定しない）
+      return item;
+    }
+
+    const processed = resultMedia.find((m) => normalizePathForCompare(m.original_path) === key);
+    return {
+      ...item,
+      progress: 100,
+      status: processed?.new_path ? ('completed' as const) : ('error' as const),
+      new_path: processed?.new_path ?? '',
+      // 結果のログを取り込む（リトライ対象の処理ログを LogViewer で確認できる）
+      logs: processed?.logs ?? item.logs,
+    };
+  });
+}
+
+/**
+ * リトライ対象（前回失敗した項目）を抽出する。
+ */
+export function selectRetryTargets(fullList: MediaInfo[]): MediaInfo[] {
+  return fullList.filter((item) => item.status === 'error');
+}


### PR DESCRIPTION
## 概要

リトライ（RETRY FAILED）が失敗ファイルだけでなく **全ファイルを再処理**していた不具合を修正する。Refs #6（コードはマージするが、実機 golden path 確認まで Issue は open のまま）。

## 原因

`retryFailedFiles()` は失敗ファイルを pending に戻した後 `processMedia()` を呼ぶが、`processMedia` は常に **mediaList 全件**を `process_media_with_settings` に送っていた。よって完了済みファイルまで再コピー・再リネームされていた。

さらに結果マージ（旧 App.tsx）は「result.media に居ない項目＝error」と判定するため、単純に対象を絞ると完了済みが誤って error 化する二次バグも潜在していた。

## 修正

- `processMedia(itemsToProcess?: MediaInfo[])` … 引数ありでそのサブセットのみ処理（リトライ時は失敗ファイルのみ）。省略時は全件（初回）。
- 結果マージを純粋関数 `mergeProcessResults(full, targets, resultMedia)` に抽出。**今回処理した対象だけ更新し、対象外（完了済み）は参照ごと据え置く**。完了済みの再処理・誤 error 化を同時に防ぐ。
- リトライの処理ログも結果から取り込み、LogViewer で対象ファイルのログを確認できるようにした。
- `selectRetryTargets()` で失敗ファイル抽出を明示化。

## テスト

photo-returns フロントには test runner が無かったため、姉妹リポ **sss #51 と同様に vitest を最小導入**し、純粋関数の回帰テストを追加（CI に `npm test` を追加）:

- `src/lib/processResults.test.ts`（5件）… 完了済みが参照ごと不変であること / 結果に無い対象は error / Windows パス正規化 / リトライログ取り込み / `selectRetryTargets`
- `npm run build`（tsc + vite）/ `npm run lint` / `npm test` すべて green

> 注: 失敗パスの GUI 再現は困難なため、バグの核心（マージ・リトライ抽出）を純粋関数化して機械検証する方針を採った。