### PR TITLE
fix: timezone_offset 補正をリネームに適用する (#5)

### DIFF
--- a/src-tauri/src/photo_core/mod.rs
+++ b/src-tauri/src/photo_core/mod.rs
@@ -1,7 +1,7 @@
 /// 写真・動画リネームのコア機能
 /// y4m2d2の完全移植版
 use anyhow::Result;
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Duration, Local, TimeZone};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -383,6 +383,85 @@ pub fn scan_media(input_dir: &Path, options: &ProcessOptions) -> Result<Vec<Medi
     Ok(result)
 }
 
+/// タイムゾーン補正の基準オフセット（秒）。
+/// docs/development.md「日本時間（UTC+9）基準で補正」に基づき JST を正本とする。
+const JST_OFFSET_SECONDS: i64 = 9 * 3600;
+
+/// "+09:00" / "-05:30" 形式のオフセット文字列を秒に変換する。形式不正は None。
+fn parse_offset_seconds(s: &str) -> Option<i64> {
+    let bytes = s.as_bytes();
+    if bytes.len() != 6 || bytes[3] != b':' {
+        return None;
+    }
+    let sign = match bytes[0] {
+        b'+' => 1,
+        b'-' => -1,
+        _ => return None,
+    };
+    let hh: i64 = s.get(1..3)?.parse().ok()?;
+    let mm: i64 = s.get(4..6)?.parse().ok()?;
+    if hh > 23 || mm > 59 {
+        return None;
+    }
+    Some(sign * (hh * 3600 + mm * 60))
+}
+
+/// ユーザー選択の `overrides.timezone_offset` に従い、撮影日時を JST(UTC+9) 基準へ補正する。
+///
+/// - `None` / `"none"` → 補正しない
+/// - `"exif"` → EXIF 埋め込みの TZ（`dates.timezone`）を元オフセットとみなす。不明なら補正しない
+/// - `"+HH:MM"` / `"-HH:MM"` → その値を元オフセットとみなす。不正値なら補正しない
+///
+/// 補正量 = `JST_OFFSET_SECONDS - source_offset` を撮影日時の wall-clock に加算する。
+/// naive wall-clock 上で加算するためマシンのローカル TZ に依存しない。補正に伴い
+/// `derived.new_name` を作り直す。
+fn apply_timezone_correction(item: &mut MediaInfo) {
+    let Some(date) = item.dates.date_taken else {
+        return;
+    };
+    let source_offset = match item.overrides.timezone_offset.as_deref() {
+        None | Some("none") => return,
+        Some("exif") => match item
+            .dates
+            .timezone
+            .as_deref()
+            .and_then(parse_offset_seconds)
+        {
+            Some(off) => off,
+            None => return,
+        },
+        Some(other) => match parse_offset_seconds(other) {
+            Some(off) => off,
+            None => return,
+        },
+    };
+
+    let shift = JST_OFFSET_SECONDS - source_offset;
+    if shift == 0 {
+        return;
+    }
+
+    let corrected_naive = date.naive_local() + Duration::seconds(shift);
+    let Some(corrected) = Local.from_local_datetime(&corrected_naive).single() else {
+        return;
+    };
+
+    item.dates.date_taken = Some(corrected);
+    let extension = item
+        .source
+        .original_path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    item.derived.new_name = format_filename(&corrected, item.dates.subsec_time, extension);
+    item.add_log(
+        LogLevel::Info,
+        format!(
+            "Timezone correction applied (source offset {source_offset}s -> JST, shift {shift}s)"
+        ),
+    );
+}
+
 /// 事前スキャン済みのメディアリストを使って処理する
 /// フロントエンドでユーザーが設定した date_source / timezone_offset / rotation_mode を尊重する
 pub fn process_media_with_list(
@@ -424,6 +503,10 @@ fn process_media_inner(
                 LogLevel::Info,
                 format!("Processing started: {}", item.source.file_name),
             );
+
+            // ユーザー選択のタイムゾーン補正を撮影日時へ適用してから
+            // 出力ディレクトリ階層・ファイル名を決定する（#5）。
+            apply_timezone_correction(item);
 
             // バックアップ作成
             if let Some(ref backup_dir) = options.backup_dir {
@@ -787,5 +870,155 @@ mod tests {
             actual, expected,
             "ProcessOptions の JSON キーが snake_case 契約と一致しません（rename_all を足すとフロント配線が壊れる）"
         );
+    }
+
+    fn local_dt(y: i32, mo: u32, d: u32, h: u32, mi: u32, s: u32) -> DateTime<Local> {
+        Local.with_ymd_and_hms(y, mo, d, h, mi, s).single().unwrap()
+    }
+
+    /// タイムゾーン補正テスト用に最小の MediaInfo を組み立てる。
+    fn tz_item(
+        date: DateTime<Local>,
+        subsec: Option<u32>,
+        tz_override: Option<&str>,
+        exif_tz: Option<&str>,
+    ) -> MediaInfo {
+        MediaInfo {
+            source: MediaSource {
+                original_path: PathBuf::from("/in/IMG.jpg"),
+                file_name: "IMG.jpg".to_string(),
+                media_type: MediaType::Photo,
+                file_size: 0,
+                exif_orientation: None,
+                width: None,
+                height: None,
+            },
+            dates: DateCandidates {
+                date_taken: Some(date),
+                subsec_time: subsec,
+                timezone: exif_tz.map(|s| s.to_string()),
+                exif_date: None,
+                filename_date: None,
+                file_created_date: None,
+                file_modified_date: None,
+                date_source: DateSource::Exif,
+            },
+            derived: DerivedOutput {
+                new_name: format_filename(&date, subsec, "jpg"),
+                new_path: PathBuf::new(),
+                rotation_applied: false,
+                burst_group_id: None,
+                burst_index: None,
+            },
+            overrides: UserOverrides {
+                timezone_offset: tz_override.map(|s| s.to_string()),
+                rotation_mode: None,
+            },
+            logs: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn parse_offset_seconds_handles_valid_and_invalid() {
+        assert_eq!(parse_offset_seconds("+09:00"), Some(32400));
+        assert_eq!(parse_offset_seconds("+00:00"), Some(0));
+        assert_eq!(parse_offset_seconds("-05:30"), Some(-19800));
+        assert_eq!(parse_offset_seconds("+14:00"), Some(50400));
+        // 不正形式
+        assert_eq!(parse_offset_seconds("none"), None);
+        assert_eq!(parse_offset_seconds("0900"), None);
+        assert_eq!(parse_offset_seconds("+9:00"), None);
+        assert_eq!(parse_offset_seconds("+25:00"), None);
+        assert_eq!(parse_offset_seconds("+09:60"), None);
+    }
+
+    #[test]
+    fn tz_correction_utc_assumed_shifts_plus_9h() {
+        // +00:00 を選択＝UTC と仮定し JST へ補正（mock-data と一致）
+        let mut item = tz_item(local_dt(2024, 1, 1, 15, 0, 0), None, Some("+00:00"), None);
+        apply_timezone_correction(&mut item);
+        assert_eq!(
+            item.dates.date_taken.unwrap(),
+            local_dt(2024, 1, 2, 0, 0, 0)
+        );
+        assert_eq!(item.derived.new_name, "2024-01-02_00-00-00.jpg");
+    }
+
+    #[test]
+    fn tz_correction_jst_is_noop() {
+        // +09:00（既に JST）→ shift 0 で無補正、ファイル名も不変
+        let mut item = tz_item(local_dt(2024, 6, 1, 12, 30, 0), None, Some("+09:00"), None);
+        apply_timezone_correction(&mut item);
+        assert_eq!(
+            item.dates.date_taken.unwrap(),
+            local_dt(2024, 6, 1, 12, 30, 0)
+        );
+        assert_eq!(item.derived.new_name, "2024-06-01_12-30-00.jpg");
+    }
+
+    #[test]
+    fn tz_correction_none_and_unset_are_noop() {
+        for sel in [Some("none"), None] {
+            let mut item = tz_item(local_dt(2024, 1, 1, 10, 0, 0), None, sel, Some("+00:00"));
+            apply_timezone_correction(&mut item);
+            assert_eq!(
+                item.dates.date_taken.unwrap(),
+                local_dt(2024, 1, 1, 10, 0, 0)
+            );
+        }
+    }
+
+    #[test]
+    fn tz_correction_exif_uses_embedded_offset() {
+        // exif 選択＋EXIF TZ +00:00 → +9h
+        let mut item = tz_item(
+            local_dt(2024, 1, 1, 15, 0, 0),
+            None,
+            Some("exif"),
+            Some("+00:00"),
+        );
+        apply_timezone_correction(&mut item);
+        assert_eq!(
+            item.dates.date_taken.unwrap(),
+            local_dt(2024, 1, 2, 0, 0, 0)
+        );
+    }
+
+    #[test]
+    fn tz_correction_exif_without_embedded_tz_is_noop() {
+        let mut item = tz_item(local_dt(2024, 1, 1, 15, 0, 0), None, Some("exif"), None);
+        apply_timezone_correction(&mut item);
+        assert_eq!(
+            item.dates.date_taken.unwrap(),
+            local_dt(2024, 1, 1, 15, 0, 0)
+        );
+    }
+
+    #[test]
+    fn tz_correction_invalid_offset_is_noop() {
+        let mut item = tz_item(local_dt(2024, 1, 1, 15, 0, 0), None, Some("garbage"), None);
+        apply_timezone_correction(&mut item);
+        assert_eq!(
+            item.dates.date_taken.unwrap(),
+            local_dt(2024, 1, 1, 15, 0, 0)
+        );
+    }
+
+    #[test]
+    fn tz_correction_negative_offset_and_subsec_preserved() {
+        // -05:00 → shift = 32400 - (-18000) = 50400s = +14h
+        let mut item = tz_item(
+            local_dt(2024, 1, 1, 10, 0, 0),
+            Some(123),
+            Some("-05:00"),
+            None,
+        );
+        apply_timezone_correction(&mut item);
+        assert_eq!(
+            item.dates.date_taken.unwrap(),
+            local_dt(2024, 1, 2, 0, 0, 0)
+        );
+        // subsec はミリ秒なので TZ で動かず保持される
+        assert_eq!(item.derived.new_name, "2024-01-02_00-00-00-123.jpg");
     }
 }

--- a/src-tauri/src/photo_core/mod.rs
+++ b/src-tauri/src/photo_core/mod.rs
@@ -388,7 +388,13 @@ pub fn scan_media(input_dir: &Path, options: &ProcessOptions) -> Result<Vec<Medi
 const JST_OFFSET_SECONDS: i64 = 9 * 3600;
 
 /// "+09:00" / "-05:30" 形式のオフセット文字列を秒に変換する。形式不正は None。
+///
+/// 受理する範囲は実在するタイムゾーンと UI ドロップダウン（docs/development.md）に合わせ
+/// `-12:00`（-43200s）〜 `+14:00`（+50400s）。範囲外は None。
 fn parse_offset_seconds(s: &str) -> Option<i64> {
+    const MIN_OFFSET: i64 = -12 * 3600; // -12:00
+    const MAX_OFFSET: i64 = 14 * 3600; // +14:00
+
     let bytes = s.as_bytes();
     if bytes.len() != 6 || bytes[3] != b':' {
         return None;
@@ -403,7 +409,11 @@ fn parse_offset_seconds(s: &str) -> Option<i64> {
     if hh > 23 || mm > 59 {
         return None;
     }
-    Some(sign * (hh * 3600 + mm * 60))
+    let total = sign * (hh * 3600 + mm * 60);
+    if !(MIN_OFFSET..=MAX_OFFSET).contains(&total) {
+        return None;
+    }
+    Some(total)
 }
 
 /// ユーザー選択の `overrides.timezone_offset` に従い、撮影日時を JST(UTC+9) 基準へ補正する。
@@ -443,6 +453,12 @@ fn apply_timezone_correction(item: &mut MediaInfo) {
 
     let corrected_naive = date.naive_local() + Duration::seconds(shift);
     let Some(corrected) = Local.from_local_datetime(&corrected_naive).single() else {
+        // ローカル TZ の DST gap/fold に当たり一意に解決できなかった場合は無補正にする
+        // （JST は DST 無しなので通常は発生しない）。
+        item.add_log(
+            LogLevel::Warning,
+            format!("Timezone correction skipped: ambiguous local time after shift {shift}s"),
+        );
         return;
     };
 
@@ -924,12 +940,28 @@ mod tests {
         assert_eq!(parse_offset_seconds("+00:00"), Some(0));
         assert_eq!(parse_offset_seconds("-05:30"), Some(-19800));
         assert_eq!(parse_offset_seconds("+14:00"), Some(50400));
+        assert_eq!(parse_offset_seconds("-12:00"), Some(-43200));
         // 不正形式
         assert_eq!(parse_offset_seconds("none"), None);
         assert_eq!(parse_offset_seconds("0900"), None);
         assert_eq!(parse_offset_seconds("+9:00"), None);
         assert_eq!(parse_offset_seconds("+25:00"), None);
         assert_eq!(parse_offset_seconds("+09:60"), None);
+        // 仕様レンジ（-12:00〜+14:00）外は弾く
+        assert_eq!(parse_offset_seconds("+15:00"), None);
+        assert_eq!(parse_offset_seconds("-13:00"), None);
+    }
+
+    #[test]
+    fn tz_correction_half_hour_offset() {
+        // -05:30 → shift = 32400 - (-19800) = 52200s = +14:30
+        let mut item = tz_item(local_dt(2024, 1, 1, 9, 0, 0), None, Some("-05:30"), None);
+        apply_timezone_correction(&mut item);
+        assert_eq!(
+            item.dates.date_taken.unwrap(),
+            local_dt(2024, 1, 1, 23, 30, 0)
+        );
+        assert_eq!(item.derived.new_name, "2024-01-01_23-30-00.jpg");
     }
 
     #[test]


### PR DESCRIPTION
## 概要

タイムゾーン補正の設定（per-item ドロップダウン）が**実際のリネームに反映されていなかった**不具合を修正する。Refs #5（コードはマージするが、実機 golden 確認まで Issue は open のまま）。

## 原因

`process_media_with_list` は「date_source / timezone_offset / rotation_mode を尊重する」と謳うが、実際は **rotation_mode しか適用していなかった**（mod.rs:556）。per-item の `overrides.timezone_offset` は backend に届くのに、日時計算・ファイル名生成に一切使われず、`date_taken` も `new_name` もスキャン時の値のままだった。

## 修正

`apply_timezone_correction(item)` を追加し、各アイテム処理の先頭（出力ディレクトリ階層・ファイル名生成の前）で呼ぶ。

### 意味論（docs 準拠）
`docs/development.md`「日本時間（UTC+9）基準で補正」/ `mock-data.ts`「+00:00 = UTC と仮定して JST に補正」に基づく:

- 選択オフセット X = 「この撮影日時は実際は TZ=X」とみなし、JST(UTC+9) 基準へ補正
- **shift = 32400(JST秒) − source_offset秒** を撮影日時の wall-clock に加算（naive 上で計算しマシン TZ 非依存）
- `none`/未設定 → 無補正 / `exif` → EXIF 埋め込み TZ / `+HH:MM` → その値 / 不正値 → 無補正
- 例: `+00:00`→ +9h（15:00→翌00:00）、`+09:00`→ 0（日本写真は無補正）

補正に伴い `format_filename` で `new_name` を作り直し、補正ログも付与。

## テスト

Rust characterization テスト8件で意味論を固定:
- `tz_correction_*`: +00:00→+9h / +09:00→noop / none・unset→noop / exif（埋め込みあり/なし）/ 不正値→noop / 負オフセット+subsec保持
- `parse_offset_seconds_*`: 正常・境界（+25:00, +09:60, 桁不足）
- `cargo test` 37 passed / `cargo clippy --all-targets -- -D warnings` 緑

## スコープ外（follow-up）

#5 チェックリストの「補正前後のファイル名プレビュー」はライブ表示のため TS 側に shift ロジックを二重化する設計判断を要する。本 PR（backend core）には含めず、core 検証後に別途相談する。