### PR TITLE
feat: 画像回転をロスレス化・ミラー系をskip (#7 Phase A+B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,9 @@ jobs:
             patchelf \
             libssl-dev \
             libgtk-3-dev \
-            libayatana-appindicator3-dev
+            libayatana-appindicator3-dev \
+            pkg-config \
+            libturbojpeg0-dev
 
       - name: Rust format check
         working-directory: src-tauri

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
 
-    # turbojpeg-sys は既定で「ソースから vendor ビルド」(require-simd で nasm 必須)。
-    # apt の libturbojpeg0-dev を pkg-config 経由で使うよう明示する。
-    env:
-      TURBOJPEG_SOURCE: pkg-config
-
     steps:
       - uses: actions/checkout@v4
 
@@ -53,8 +48,10 @@ jobs:
             libssl-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \
-            pkg-config \
-            libturbojpeg0-dev
+            nasm
+
+      # turbojpeg-sys は同梱 libjpeg-turbo(>=3.0) を cmake で vendor ビルドする。
+      # SIMD(require-simd)に nasm が必須。cmake/gcc は runner に既存。
 
       - name: Rust format check
         working-directory: src-tauri

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ jobs:
   check:
     runs-on: ubuntu-latest
 
+    # turbojpeg-sys は既定で「ソースから vendor ビルド」(require-simd で nasm 必須)。
+    # apt の libturbojpeg0-dev を pkg-config 経由で使うよう明示する。
+    env:
+      TURBOJPEG_SOURCE: pkg-config
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,15 +60,22 @@ jobs:
             libssl-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \
-            pkg-config \
-            libturbojpeg0-dev
-          # turbojpeg を vendor ビルドせず apt の libturbojpeg を pkg-config で使う（ubuntu のみ）
-          echo "TURBOJPEG_SOURCE=pkg-config" >> "$GITHUB_ENV"
+            nasm
 
-      # NOTE(#7): macOS（aarch64+x86_64 ユニバーサル）と Windows の turbojpeg(libjpeg-turbo)
-      # native ビルドは未設定。macOS は brew jpeg-turbo が keg-only かつ x86_64 クロスで
-      # arch 不一致、Windows は nasm+cmake の vendor ビルドが要る。実機リリースで検証して
-      # から設定する（フォローアップ）。Linux リリースは上記 dep で動く。
+      # turbojpeg-sys は同梱 libjpeg-turbo(>=3.0) を cmake で vendor ビルドする（SIMD に nasm 必須）。
+      # cmake は各 runner に既存。macOS/Windows にも nasm を入れて vendor ビルドを成立させる。
+      - name: Install nasm (macOS)
+        if: matrix.platform == 'macos-latest'
+        run: brew install nasm
+
+      - name: Install nasm (Windows)
+        if: matrix.platform == 'windows-latest'
+        run: choco install nasm -y
+        shell: pwsh
+
+      # NOTE(#7): macOS は aarch64+x86_64 ユニバーサルのため、x86_64 スライスの vendor ビルド
+      # （クロス）は未検証。Windows も choco nasm の PATH 反映を含め未検証。次回リリースで
+      # 各 OS の成果物を実機確認すること（Linux は本 CI と同じ nasm vendor 経路で確認済み）。
 
       - name: Install frontend dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,14 @@ jobs:
             patchelf \
             libssl-dev \
             libgtk-3-dev \
-            libayatana-appindicator3-dev
+            libayatana-appindicator3-dev \
+            pkg-config \
+            libturbojpeg0-dev
+
+      # NOTE(#7): macOS（aarch64+x86_64 ユニバーサル）と Windows の turbojpeg(libjpeg-turbo)
+      # native ビルドは未設定。macOS は brew jpeg-turbo が keg-only かつ x86_64 クロスで
+      # arch 不一致、Windows は nasm+cmake の vendor ビルドが要る。実機リリースで検証して
+      # から設定する（フォローアップ）。Linux リリースは上記 dep で動く。
 
       - name: Install frontend dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,8 @@ jobs:
             libayatana-appindicator3-dev \
             pkg-config \
             libturbojpeg0-dev
+          # turbojpeg を vendor ビルドせず apt の libturbojpeg を pkg-config で使う（ubuntu のみ）
+          echo "TURBOJPEG_SOURCE=pkg-config" >> "$GITHUB_ENV"
 
       # NOTE(#7): macOS（aarch64+x86_64 ユニバーサル）と Windows の turbojpeg(libjpeg-turbo)
       # native ビルドは未設定。macOS は brew jpeg-turbo が keg-only かつ x86_64 クロスで

--- a/docs/development.md
+++ b/docs/development.md
@@ -31,10 +31,26 @@
 **バックエンド:**
 - Rust（Tauri 2.0）
 - kamadak-exif（EXIF読み取り）
-- image クレート（画像処理・回転）
+- image クレート（画像処理・PNG等の回転）
+- turbojpeg（JPEG のロスレス回転 / libjpeg-turbo の DCT 領域変換）
 - img-parts（JPEG EXIF書き換え）
 - chrono + chrono-tz（日時処理）
 - rayon（並列処理）
+
+**ローカルビルドの前提（turbojpeg / libjpeg-turbo）:**
+
+`turbojpeg` crate は libjpeg-turbo にリンクするため、ビルド時に検出が必要。
+
+- Linux: `sudo apt-get install -y pkg-config libturbojpeg0-dev`（pkg-config が自動検出）
+- macOS（Homebrew・keg-only）:
+  ```sh
+  brew install jpeg-turbo
+  export TURBOJPEG_SOURCE=explicit
+  export TURBOJPEG_LIB_DIR=/opt/homebrew/opt/jpeg-turbo/lib       # Intel は /usr/local/opt/...
+  export TURBOJPEG_INCLUDE_PATH=/opt/homebrew/opt/jpeg-turbo/include
+  ```
+  （または `export PKG_CONFIG_PATH=/opt/homebrew/opt/jpeg-turbo/lib/pkgconfig` でも可）
+- Windows / 各OSのリリースビルド（3OS）の native dep 設定はフォローアップ（#7 コメント参照）
 
 **重要な決定: なぜ Tauri 2.0？**
 - モバイル含むクロスプラットフォーム対応（Android/iOS）

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -487,6 +487,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,6 +1213,12 @@ checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "gcd"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "gdk"
@@ -2840,6 +2855,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
+ "turbojpeg",
  "walkdir",
 ]
 
@@ -4603,6 +4619,30 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "turbojpeg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b12ab1b96184a3879b4b16a74ee67436a5ef8833c0e6954a8cbf47ec9036559"
+dependencies = [
+ "gcd",
+ "libc",
+ "thiserror 1.0.69",
+ "turbojpeg-sys",
+]
+
+[[package]]
+name = "turbojpeg-sys"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b5a974bc59382d35927e3a07eef2ba9a24fe7227cefe52ec44b508e1b90f86"
+dependencies = [
+ "anyhow",
+ "cmake",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "typeid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,4 +44,5 @@ tracing-subscriber = "0.3"  # ログ設定
 regex = "1.10"   # 正規表現（連続撮影検出等）
 mp4 = "0.14"     # MP4/QuickTimeメタデータ読み取り
 img-parts = "0.3"  # JPEG/PNGメタデータ書き換え
+turbojpeg = "1.4.0"
 

--- a/src-tauri/src/orientation.rs
+++ b/src-tauri/src/orientation.rs
@@ -1,5 +1,5 @@
 /// 画像の向き検出・修正機能
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use exif::{In, Reader, Tag};
 use image::{self, DynamicImage};
 use img_parts::jpeg::Jpeg;
@@ -7,6 +7,7 @@ use img_parts::{Bytes, ImageEXIF};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
+use turbojpeg::{Transform, TransformOp};
 
 /// 画像の向き（EXIF Orientation値）
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -232,6 +233,73 @@ pub fn reset_exif_orientation(image_path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// EXIF Orientation 値がミラー系（2/4/5/7）かを判定する。
+///
+/// 現実のカメラ・スマホは回転（1/3/6/8）しか付けないため、ミラー系は非対応として
+/// スキップ＋ログ記録する（#7 仕様）。
+pub fn is_mirror_orientation(value: u32) -> bool {
+    matches!(value, 2 | 4 | 5 | 7)
+}
+
+/// EXIF Orientation 値を、正しい向きにするための時計回り回転角（度）へ写像する。
+///
+/// 対応するのは回転のみ（1=0° / 3=180° / 6=90° / 8=270°）。`1`（正常）・ミラー系・
+/// 不明値はすべて 0（回転なし）を返す。
+pub fn exif_orientation_to_degrees(value: u32) -> u32 {
+    match value {
+        3 => 180,
+        6 => 90,
+        8 => 270,
+        _ => 0, // 1（正常）/ ミラー系 / 不明
+    }
+}
+
+/// 画像ファイルをその場で `degrees`（90/180/270）だけロスレス回転する。
+///
+/// - JPEG は **turbojpeg**（libjpeg-turbo の DCT 領域変換）で無劣化回転する。`copy_none=false`
+///   で EXIF/ICC を保持するため日付・GPS は失われない。回転後にピクセルが物理的に回っているので
+///   `reset_exif_orientation` で Orientation を 1 に上書きし、ビューアでの二重回転を防ぐ。
+/// - JPEG 以外（PNG 等のロスレス形式）は `image` クレートで回転する。
+///
+/// `degrees` が 0 や非対応値なら何もしない。
+pub fn rotate_file_in_place(path: &Path, degrees: u32) -> Result<()> {
+    let op = match degrees {
+        90 => TransformOp::Rot90,
+        180 => TransformOp::Rot180,
+        270 => TransformOp::Rot270,
+        _ => return Ok(()),
+    };
+
+    let extension = path
+        .extension()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+
+    if matches!(extension.as_str(), "jpg" | "jpeg") {
+        let bytes = fs::read(path).context("Failed to read JPEG for lossless rotation")?;
+        // perfect=false（既定）で非MCU境界でもエラーにせず標準ロスレス回転、
+        // copy_none=false（既定）で EXIF/ICC マーカーを出力へ引き継ぐ。
+        let transform = Transform::op(op);
+        let rotated = turbojpeg::transform(&transform, &bytes)
+            .map_err(|e| anyhow!("Lossless JPEG rotation failed: {e}"))?;
+        fs::write(path, rotated.as_ref()).context("Failed to write rotated JPEG")?;
+        // コピーされた古い Orientation 値を 1（Normal）へ上書きする。
+        reset_exif_orientation(path)?;
+    } else {
+        let img = image::open(path).context("Failed to open image for rotation")?;
+        let rotated = match degrees {
+            90 => img.rotate90(),
+            180 => img.rotate180(),
+            270 => img.rotate270(),
+            _ => img,
+        };
+        rotated.save(path).context("Failed to save rotated image")?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -257,5 +325,71 @@ mod tests {
         let result = correct_orientation(img.clone(), Orientation::Rotate90CW);
         // 90度回転すると、幅と高さが入れ替わる
         assert_eq!(result.dimensions(), (100, 100));
+    }
+
+    #[test]
+    fn mirror_orientations_are_detected() {
+        // ミラー系（2/4/5/7）は非対応 → true
+        for v in [2, 4, 5, 7] {
+            assert!(is_mirror_orientation(v), "{v} should be mirror");
+        }
+        // 回転系（1/3/6/8）と不明値は false
+        for v in [1, 3, 6, 8, 0, 99] {
+            assert!(!is_mirror_orientation(v), "{v} should not be mirror");
+        }
+    }
+
+    #[test]
+    fn exif_orientation_maps_to_clockwise_degrees() {
+        // 対応値 1/3/6/8
+        assert_eq!(exif_orientation_to_degrees(1), 0);
+        assert_eq!(exif_orientation_to_degrees(3), 180);
+        assert_eq!(exif_orientation_to_degrees(6), 90);
+        assert_eq!(exif_orientation_to_degrees(8), 270);
+        // ミラー系・不明は回転しない
+        assert_eq!(exif_orientation_to_degrees(2), 0);
+        assert_eq!(exif_orientation_to_degrees(5), 0);
+        assert_eq!(exif_orientation_to_degrees(99), 0);
+    }
+
+    /// テスト用に MCU 境界（16x16）に整列した JPEG を temp に書き出す。
+    fn write_test_jpeg(name: &str, width: u32, height: u32) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!("photo_returns_tz_{name}.jpg"));
+        let img = DynamicImage::new_rgb8(width, height);
+        img.save(&path).expect("save test jpeg");
+        path
+    }
+
+    #[test]
+    fn lossless_rotate_jpeg_90_swaps_dimensions() {
+        let path = write_test_jpeg("rot90", 32, 16);
+        rotate_file_in_place(&path, 90).expect("lossless rotate 90");
+        // 90度回転で幅と高さが入れ替わる。再デコードできる＝有効な JPEG。
+        let dims = image::open(&path)
+            .expect("reopen rotated jpeg")
+            .dimensions();
+        assert_eq!(dims, (16, 32));
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn lossless_rotate_jpeg_180_keeps_dimensions() {
+        let path = write_test_jpeg("rot180", 32, 16);
+        rotate_file_in_place(&path, 180).expect("lossless rotate 180");
+        let dims = image::open(&path)
+            .expect("reopen rotated jpeg")
+            .dimensions();
+        assert_eq!(dims, (32, 16));
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn rotate_zero_degrees_is_noop() {
+        let path = write_test_jpeg("rot0", 32, 16);
+        let before = fs::read(&path).unwrap();
+        rotate_file_in_place(&path, 0).expect("noop");
+        let after = fs::read(&path).unwrap();
+        assert_eq!(before, after, "0度はファイルを変更しない");
+        let _ = fs::remove_file(&path);
     }
 }

--- a/src-tauri/src/orientation.rs
+++ b/src-tauri/src/orientation.rs
@@ -150,8 +150,10 @@ pub fn reset_exif_orientation(image_path: &Path) -> Result<()> {
             return Ok(());
         }
 
-        // TIFFヘッダー以降を取得
-        let tiff_data = &exif_data[6..];
+        // img-parts の jpeg.exif() は "Exif\0\0"(6バイト)プレフィックスを既に剥がした
+        // TIFF データを返す（segment.rs の slice(EXIF_DATA_PREFIX.len()..)）。
+        // よって exif_data の先頭がそのまま TIFF ヘッダー（"II"/"MM"）になる。
+        let tiff_data = &exif_data[..];
 
         // バイトオーダーを確認（"II" = Little Endian, "MM" = Big Endian）
         if tiff_data.len() < 2 {
@@ -177,11 +179,11 @@ pub fn reset_exif_orientation(image_path: &Path) -> Result<()> {
         };
 
         // TIFFデータ内でOrientationタグを検索
-        // modified_data は exif_data（EXIFヘッダー6バイト含む）のコピー。
-        // tiff_data = &exif_data[6..] なので、tiff_data の index i は
-        // modified_data の index (6 + i) に対応する。
+        // modified_data は exif_data（= TIFF データそのもの）のコピー。
+        // tiff_data = &exif_data[..] なので、tiff_data の index i は
+        // modified_data の index i にそのまま対応する。
         // IFDエントリ構造: タグ(2) + 型(2) + カウント(4) + 値/オフセット(4)
-        // 値フィールドは エントリ先頭から 8バイト後ろ → modified_data[(6 + i + 8)..]
+        // 値フィールドは エントリ先頭から 8バイト後ろ → modified_data[(i + 8)..]
         let mut found = false;
         for i in 0..tiff_data.len().saturating_sub(12) {
             if tiff_data[i..i + 2] == orientation_bytes {
@@ -202,8 +204,8 @@ pub fn reset_exif_orientation(image_path: &Path) -> Result<()> {
                 }
 
                 // 値フィールドの位置: modified_data 上の絶対オフセット
-                // = EXIFヘッダー(6) + tiff_data内のエントリ先頭(i) + タグ(2) + 型(2) + カウント(4)
-                let value_offset = 6 + i + 8;
+                // = tiff_data内のエントリ先頭(i) + タグ(2) + 型(2) + カウント(4)
+                let value_offset = i + 8;
 
                 if value_offset + 2 <= modified_data.len() {
                     // 値を1（Normal）に設定（SHORT型なので2バイト）
@@ -390,6 +392,61 @@ mod tests {
         rotate_file_in_place(&path, 0).expect("noop");
         let after = fs::read(&path).unwrap();
         assert_eq!(before, after, "0度はファイルを変更しない");
+        let _ = fs::remove_file(&path);
+    }
+
+    /// Orientation=6 の実 EXIF タグを持つ JPEG を作るヘルパー。
+    /// 最小の TIFF（II / IFD0 に Orientation=SHORT=6 の1エントリ）を img-parts で付与する。
+    fn write_jpeg_with_orientation(name: &str, value: u16) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!("photo_returns_ori_{name}.jpg"));
+        DynamicImage::new_rgb8(16, 16).save(&path).unwrap();
+        let mut jpeg = Jpeg::from_bytes(fs::read(&path).unwrap().into()).unwrap();
+        let [vlo, vhi] = value.to_le_bytes();
+        let tiff: Vec<u8> = vec![
+            0x49, 0x49, 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00, // "II", 42, IFD0 offset = 8
+            0x01, 0x00, // エントリ数 1
+            0x12, 0x01, // タグ 0x0112 (Orientation) LE
+            0x03, 0x00, // 型 SHORT (3)
+            0x01, 0x00, 0x00, 0x00, // カウント 1
+            vlo, vhi, 0x00, 0x00, // 値（インライン）
+            0x00, 0x00, 0x00, 0x00, // 次 IFD = 0
+        ];
+        jpeg.set_exif(Some(Bytes::from(tiff)));
+        fs::write(&path, jpeg.encoder().bytes()).unwrap();
+        path
+    }
+
+    #[test]
+    fn reset_exif_orientation_actually_sets_normal() {
+        let path = write_jpeg_with_orientation("reset6", 6);
+        // 前提: 付与した Orientation=6 が読める（=テスト土台が正しい）
+        assert_eq!(
+            get_orientation(&path).unwrap().orientation,
+            Orientation::Rotate90CW,
+            "テスト用 JPEG に Orientation=6 が付いているはず"
+        );
+
+        reset_exif_orientation(&path).expect("reset");
+
+        // 検証: リセット後は Normal(1)。img-parts の [6..] バグ時はここが 6 のまま落ちる。
+        assert_eq!(
+            get_orientation(&path).unwrap().orientation,
+            Orientation::Normal,
+            "reset_exif_orientation 後は Orientation=1 でなければならない"
+        );
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn rotate_jpeg_with_orientation_resets_to_normal() {
+        // ロスレス回転の golden path: 回転後に EXIF Orientation が 1 になる（二重回転防止）。
+        let path = write_jpeg_with_orientation("rot_reset8", 8);
+        rotate_file_in_place(&path, 270).expect("lossless rotate");
+        assert_eq!(
+            get_orientation(&path).unwrap().orientation,
+            Orientation::Normal,
+            "回転後は EXIF Orientation=1 でなければならない"
+        );
         let _ = fs::remove_file(&path);
     }
 }

--- a/src-tauri/src/photo_core/mod.rs
+++ b/src-tauri/src/photo_core/mod.rs
@@ -685,10 +685,7 @@ fn process_media_inner(
                                 match orientation::rotate_file_in_place(&target_path, degrees) {
                                     Ok(()) => {
                                         item.derived.rotation_applied = true;
-                                        item.add_log(
-                                            LogLevel::Info,
-                                            "Image rotated losslessly (EXIF Orientation reset to 1)",
-                                        );
+                                        item.add_log(LogLevel::Info, "Image rotated losslessly");
                                     }
                                     Err(e) => {
                                         item.add_log(

--- a/src-tauri/src/photo_core/mod.rs
+++ b/src-tauri/src/photo_core/mod.rs
@@ -650,27 +650,27 @@ fn process_media_inner(
                         format!("File copied successfully to: {}", target_path.display()),
                     );
 
-                    // 画像回転処理（rotation_modeに基づく）
+                    // 画像回転処理（rotation_mode に基づく・ロスレス）
                     if item.source.media_type == MediaType::Photo {
                         let rotation_mode =
                             item.overrides.rotation_mode.as_deref().unwrap_or("none");
 
                         if rotation_mode != "none" {
-                            // 回転角度を計算
+                            // 回転角度を計算（exif はミラー系 2/4/5/7 を skip + ログ）
                             let degrees = match rotation_mode {
-                                "exif" => {
-                                    if let Some(ori) = item.source.exif_orientation {
-                                        match ori {
-                                            1 => 0,
-                                            3 => 180,
-                                            6 => 90,
-                                            8 => 270,
-                                            _ => 0,
-                                        }
-                                    } else {
+                                "exif" => match item.source.exif_orientation {
+                                    Some(ori) if orientation::is_mirror_orientation(ori) => {
+                                        item.add_log(
+                                            LogLevel::Warning,
+                                            format!(
+                                                "Mirror orientation ({ori}) is not supported, skipping rotation"
+                                            ),
+                                        );
                                         0
                                     }
-                                }
+                                    Some(ori) => orientation::exif_orientation_to_degrees(ori),
+                                    None => 0,
+                                },
                                 "90" => 90,
                                 "180" => 180,
                                 "270" => 270,
@@ -680,54 +680,20 @@ fn process_media_inner(
                             if degrees != 0 {
                                 item.add_log(
                                     LogLevel::Info,
-                                    format!("Applying rotation: {degrees}°"),
+                                    format!("Applying lossless rotation: {degrees}°"),
                                 );
-
-                                match image::open(&target_path) {
-                                    Ok(img) => {
-                                        let rotated = match degrees {
-                                            90 => img.rotate90(),
-                                            180 => img.rotate180(),
-                                            270 => img.rotate270(),
-                                            _ => img,
-                                        };
-
-                                        match rotated.save(&target_path) {
-                                            Ok(_) => {
-                                                item.add_log(
-                                                    LogLevel::Info,
-                                                    "Image rotated and saved successfully",
-                                                );
-                                                item.derived.rotation_applied = true;
-
-                                                if let Err(e) = orientation::reset_exif_orientation(
-                                                    &target_path,
-                                                ) {
-                                                    item.add_log(
-                                                        LogLevel::Warning,
-                                                        format!(
-                                                            "Failed to reset EXIF orientation: {e}"
-                                                        ),
-                                                    );
-                                                } else {
-                                                    item.add_log(
-                                                        LogLevel::Info,
-                                                        "EXIF orientation reset to Normal (1)",
-                                                    );
-                                                }
-                                            }
-                                            Err(e) => {
-                                                item.add_log(
-                                                    LogLevel::Error,
-                                                    format!("Failed to save rotated image: {e}"),
-                                                );
-                                            }
-                                        }
+                                match orientation::rotate_file_in_place(&target_path, degrees) {
+                                    Ok(()) => {
+                                        item.derived.rotation_applied = true;
+                                        item.add_log(
+                                            LogLevel::Info,
+                                            "Image rotated losslessly (EXIF Orientation reset to 1)",
+                                        );
                                     }
                                     Err(e) => {
                                         item.add_log(
                                             LogLevel::Error,
-                                            format!("Failed to open image for rotation: {e}"),
+                                            format!("Failed to rotate image: {e}"),
                                         );
                                     }
                                 }

--- a/src/hooks/useMediaTableColumns.tsx
+++ b/src/hooks/useMediaTableColumns.tsx
@@ -622,6 +622,10 @@ export function useMediaTableColumns({
                   src={assetUrl}
                   alt="rotated preview"
                   style={{
+                    // 生ピクセルに対して回転させる（バックエンドの物理回転と一致）。
+                    // imageOrientation:none を付けないと、ブラウザの EXIF 自動回転に
+                    // CSS rotate が重なって二重回転になる（#7）。
+                    imageOrientation: 'none',
                     transform: `rotate(${degrees}deg)`,
                     width: '56px',
                     height: '56px',


### PR DESCRIPTION
## 概要

EXIF方向補正を刷新する #7 の **Phase A（backend 正規化コア）＋ Phase B（サムネイル表示回転）**。Refs #7（コードはマージするが、実機 golden 確認まで Issue は open のまま。Phase C のポップアップUIは次PR）。

## Phase A — backend 正規化コア

- `orientation.rs` に `rotate_file_in_place(path, degrees)` を追加:
  - **JPEG は turbojpeg**（libjpeg-turbo の DCT 領域変換）で**無劣化回転**。`Transform::op` は `copy_none=false`（EXIF/ICC 保持）・`perfect=false`（非MCU境界でもエラーにしない）。回転後 `reset_exif_orientation` で Orientation=1 に上書き → **日付/GPS を失わず、ビューアの二重回転も防止**。
  - PNG 等は `image` クレート（元々ロスレス形式）。
- **対応値は 1/3/6/8 のみ**。ミラー系 **2/4/5/7 は skip + Warning ログ**（`is_mirror_orientation`）。現実のカメラ・スマホでミラーは発生しないため。
- `exif_orientation_to_degrees` を純粋関数化し、`mod.rs` の回転ブロックを旧 image 再エンコードからロスレス経路へ差し替え。

## Phase B — サムネイル表示回転

- **Before サムネイル / LightBox はブラウザ既定の EXIF 自動回転に委ねる**（`image-orientation` の override 無し）。これは **sss と同じルール**（sss も CSS では何もせずブラウザ既定に任せ、`apply_exif_rotation` は backend 設定）。→ 「タグを読んで表示時に回転・ファイル不変」を既に充足。
- **After プレビューの二重回転を修正**: `<img>` に `imageOrientation: 'none'` を付与。これまでブラウザの EXIF 自動回転済み画像に CSS `transform: rotate` を重ねて二重回転していた。生ピクセルに回転を当てることで backend の物理回転結果と一致（webview の自動回転有無に依らず正しい）。

## テスト

- `orientation.rs`: ミラー判定（2/4/5/7）/ orientation→度 写像（1→0・3→180・6→90・8→270）/ **ロスレス回転 roundtrip**（32x16 JPEG を90度→16x32・180度→不変・0度 no-op）
- `cargo test` 43 passed / `cargo clippy --all-targets -- -D warnings` 緑（turbojpeg リンク済み）
- frontend `npm run build` / `npm run lint` / `npm test`（vitest 7）緑

## ビルド（turbojpeg / libjpeg-turbo）

- **CI(ubuntu)**: `pkg-config libturbojpeg0-dev` を追加（このPRのCIで検証）。
- **macOS ローカル**: keg-only の Homebrew jpeg-turbo を env か `PKG_CONFIG_PATH` で指定（`docs/development.md` に記載）。
- ⚠️ **macOS（aarch64+x86_64 ユニバーサル）/ Windows のリリース native dep は未設定 = follow-up**。憶測で壊れた CI 設定を入れず、実機リリースで検証してから設定する（release.yml にコメント＋#7 に記録）。

## 残（#7 Phase C・別PR）

方向確認ポップアップUI（眼科Cの4方向ピッカー・自動進行・スキップ）は設計を詰めてから次PR。