### PR TITLE
feat: ファイル処理の進捗を Channel でリアルタイム化 (#4)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -267,7 +267,7 @@ output/
 ### バックエンド (src-tauri/src/)
 
 **コアファイル:**
-- `lib.rs` - Tauri コマンド定義（scan_media, process_media, reveal_in_filemanager）
+- `lib.rs` - Tauri コマンド定義（scan_media, process_media, process_media_with_settings, reveal_in_filemanager）。`process_media_with_settings` は `Channel<ProgressEvent>` でリアルタイム進捗を送る（#4）
 - `photo_core/` - コア処理ロジック（責務別モジュール）
   - `mod.rs` - 公開型（MediaInfo / ProcessOptions / ProcessResult / MediaType / DateSource 等）とパイプライン（scan_media / process_media / process_media_with_list）
     - メディアスキャン
@@ -393,10 +393,39 @@ npm run format:rust:check  # rustfmt チェック
 - **詳細ログ**: デバッグ用に全ステップ記録
 - **リトライ機能**: エラーファイルのみ再処理可能
 
+### リアルタイム進捗（Channel 方式 / #4）
+
+処理は `process_media_with_settings` コマンドで実行し、進捗を Tauri 2 の
+`tauri::ipc::Channel<ProgressEvent>` でファイル1件完了ごとにフロントへ送る。フェイクの
+0%→100% は廃止した。
+
+- **バックエンド (`photo_core/mod.rs`)**
+  - `ProgressEvent { done, total, path, status }`（`done` は完了済み件数 1..=total、
+    `status` は `completed` / `error`）を1ファイルの処理が終わるたびに1回 emit する。
+  - 並列(rayon)処理でも `done` は `Arc<AtomicUsize>` の `fetch_add` で採番するため、
+    到着順に関係なく 1..=total を1度ずつ網羅する（取りこぼし・重複なし）。
+  - 処理本体は `process_one(item) -> ProgressStatus` に切り出し、早期 return（バックアップ
+    失敗・ディレクトリ作成失敗など）もステータスを返して抜けることで、結果を問わず
+    「1ファイル1イベント」を構造的に保証する（return 漏れによるカウント取りこぼし防止）。
+  - 進捗パーセントは純関数 `progress_percent(done, total)`（0-100整数、端数切り捨て、
+    `total==0` は 100）で計算し、フロントの `progressPercent` と同式。
+- **コマンド境界 (`lib.rs`)**
+  - `process_media_with_settings(..., on_progress: Channel<ProgressEvent>)`。チャネル送信
+    失敗（フロントが listener を破棄した等）は処理継続を妨げないため握り潰す。
+- **フロントエンド (`App.tsx` / `lib/processResults.ts`)**
+  - invoke 時に `new Channel<ProgressEvent>()` を渡し、`onmessage` で `applyProgressEvent`
+    により該当行の `status`/`progress` をライブ更新する。`setMediaList` は関数更新形を使い
+    stale closure を避ける。
+  - invoke 直前に `markTargetsProcessing` で対象行を `processing`/`progress=0` にリセット。
+  - 全体進捗バーは `MainLayout` に表示（`progressPercent(done, total)`）。`done` は単調増加で
+    更新する。
+  - 処理完了後、`new_path`/`logs` 等の確定値は従来どおり `mergeProcessResults`（#6）で
+    上書きする。ライブ進捗（`applyProgressEvent`）は表示のみで `new_path`/`logs` を触らない。
+  - **リトライ**（失敗ファイルのみ再処理）でも `total = targets.length` なので進捗が正しく出る。
+
 ## 今後の拡張機能（オプション）
 
 ### 潜在的な機能
-- リアルタイム進捗ストリーミング（現在は0%か100%のみ）
 - バックアップディレクトリオプション（UI統合）
 - カスタム日付フォーマット設定
 - 重複検出（ハッシュベース）

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,9 +3,10 @@ pub mod orientation;
 pub mod photo_core;
 pub mod video_metadata;
 
-use photo_core::{MediaInfo, ProcessOptions, ProcessResult};
+use photo_core::{MediaInfo, ProcessOptions, ProcessResult, ProgressEvent};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use tauri::ipc::Channel;
 
 /// 指定ディレクトリのメディアファイルをスキャンして情報を取得
 #[tauri::command]
@@ -46,6 +47,12 @@ fn process_media(
 }
 
 /// 事前スキャン済みメディアリストを使って処理（UIの設定を尊重）
+///
+/// 進捗はファイル1件完了ごとに `on_progress` チャネルへ `ProgressEvent` を送る（#4）。
+/// フロントは invoke 時に `new Channel<ProgressEvent>()` を渡し、`onmessage` で
+/// 該当行と全体進捗をリアルタイム更新する。並列(rayon)処理でも `done` は 1..=total を
+/// 1度ずつ採番するため取りこぼし・重複しない。チャネルは `Send + Sync` で複数スレッドから
+/// 安全に送れる。
 #[tauri::command]
 fn process_media_with_settings(
     media_list: Vec<MediaInfo>,
@@ -54,6 +61,7 @@ fn process_media_with_settings(
     parallel: bool,
     include_videos: bool,
     cleanup_temp: bool,
+    on_progress: Channel<ProgressEvent>,
 ) -> Result<ProcessResult, String> {
     let output_path = PathBuf::from(output_dir);
     let backup_path = backup_dir.map(PathBuf::from);
@@ -68,8 +76,11 @@ fn process_media_with_settings(
     };
 
     let mut media = media_list;
-    photo_core::process_media_with_list(&mut media, &output_path, &options)
-        .map_err(|e| e.to_string())
+    photo_core::process_media_with_list_progress(&mut media, &output_path, &options, move |ev| {
+        // チャネル送信失敗（フロントが listener を破棄した等）は処理継続を妨げないため握り潰す。
+        let _ = on_progress.send(ev);
+    })
+    .map_err(|e| e.to_string())
 }
 
 /// ファイルをファイラーで開く（ファイルを選択した状態）

--- a/src-tauri/src/photo_core/mod.rs
+++ b/src-tauri/src/photo_core/mod.rs
@@ -6,6 +6,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use walkdir::WalkDir;
 
@@ -175,6 +176,45 @@ pub struct ProcessResult {
     pub processed_files: usize,
     pub media: Vec<MediaInfo>,
     pub errors: Vec<String>,
+}
+
+/// 進捗イベント（ファイル1件完了ごとにフロントへ送る、#4）
+///
+/// `process_media_with_list` の処理ループから各ファイルの完了時（成功/失敗の両方）に
+/// 1 回ずつ emit する。`done` は「完了済み件数」（このイベント自身を含む。並列処理では
+/// `Arc<AtomicUsize>` で採番するため到着順とは無関係に 1..=total を1度ずつ網羅する）。
+/// フロントは `original_path` で該当行を引き当て、`done`/`total` から全体進捗を更新する。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProgressEvent {
+    /// 完了済み件数（1..=total）。このイベントの分を含む。
+    pub done: usize,
+    /// 総件数（今回処理する対象数。リトライ時は失敗ファイル数）。
+    pub total: usize,
+    /// 完了したファイルの元パス（フロントの行引き当てキー）。
+    pub path: String,
+    /// このファイルの結果（"completed" / "error"）。
+    pub status: ProgressStatus,
+}
+
+/// 進捗イベントのファイル単位ステータス
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProgressStatus {
+    Completed,
+    Error,
+}
+
+/// done/total から進捗パーセント（0-100, 整数）を求める純関数。
+///
+/// `total == 0` のときは 100 を返す（処理対象ゼロ＝完了扱い）。端数は切り捨て、
+/// `done >= total` は 100 に丸める。フロント/バックエンドで同じ式を使うため切り出す。
+pub fn progress_percent(done: usize, total: usize) -> u32 {
+    if total == 0 {
+        return 100;
+    }
+    let done = done.min(total);
+    ((done as u64 * 100) / total as u64) as u32
 }
 
 /// ログエントリを追加するヘルパー
@@ -485,7 +525,24 @@ pub fn process_media_with_list(
     output_dir: &Path,
     options: &ProcessOptions,
 ) -> Result<ProcessResult> {
-    process_media_inner(media, output_dir, options)
+    process_media_inner(media, output_dir, options, |_| {})
+}
+
+/// 進捗コールバック付きで事前スキャン済みのメディアリストを処理する（#4）。
+///
+/// `on_progress` はファイル1件の処理が終わるたび（成功/失敗の両方）に1回ずつ呼ばれる。
+/// 並列処理時は複数スレッドから呼ばれ得るので、コールバック側はスレッドセーフであること
+/// （Tauri の `ipc::Channel` は `Send + Sync` で、内部で順序づけて送る）。
+pub fn process_media_with_list_progress<F>(
+    media: &mut Vec<MediaInfo>,
+    output_dir: &Path,
+    options: &ProcessOptions,
+    on_progress: F,
+) -> Result<ProcessResult>
+where
+    F: Fn(ProgressEvent) + Sync + Send,
+{
+    process_media_inner(media, output_dir, options, on_progress)
 }
 
 /// メディアファイルをリネームして階層構造にコピー（再スキャンあり版、CLI用）
@@ -495,25 +552,50 @@ pub fn process_media(
     options: &ProcessOptions,
 ) -> Result<ProcessResult> {
     let mut media = scan_media(input_dir, options)?;
-    process_media_inner(&mut media, output_dir, options)
+    process_media_inner(&mut media, output_dir, options, |_| {})
 }
 
 /// メディアファイルをリネームして階層構造にコピー（内部実装）
-fn process_media_inner(
+///
+/// `on_progress` はファイル1件完了ごと（成功/失敗の両方）に呼ばれる。並列(rayon)時は
+/// 複数スレッドから同時に呼ばれるため `Sync + Send` を要求する。`done` カウンタは
+/// `Arc<AtomicUsize>` で採番し、到着順に関係なく 1..=total を1度ずつ網羅する。
+fn process_media_inner<F>(
     media: &mut Vec<MediaInfo>,
     output_dir: &Path,
     options: &ProcessOptions,
-) -> Result<ProcessResult> {
+    on_progress: F,
+) -> Result<ProcessResult>
+where
+    F: Fn(ProgressEvent) + Sync + Send,
+{
     let total_files = media.len();
 
     let errors = Arc::new(Mutex::new(Vec::new()));
     let success_count = Arc::new(Mutex::new(0_usize));
+    // 完了済み件数（成功/失敗を問わない）。並列でも競合しないよう Atomic で採番する。
+    let done_count = Arc::new(AtomicUsize::new(0));
 
     // TOCTOU競合防止: ファイル名スロット割り当てとコピーをアトミックに行うためのロック。
     // 並列処理時に複数スレッドが同じ出力パスへ同時書き込みするのを防ぐ。
     let file_slot_lock = Arc::new(Mutex::new(()));
 
-    let processor = |item: &mut MediaInfo| {
+    // ファイル1件の処理が終わるたびに進捗イベントを1回送る。
+    let emit_progress = |item: &MediaInfo, status: ProgressStatus| {
+        // fetch_add は加算前の値を返すので +1 が「このファイルを含む完了件数」。
+        let done = done_count.fetch_add(1, Ordering::SeqCst) + 1;
+        on_progress(ProgressEvent {
+            done,
+            total: total_files,
+            path: item.source.original_path.to_string_lossy().to_string(),
+            status,
+        });
+    };
+
+    // 1ファイルを処理し、結果ステータス（Completed / Error）を返す。
+    // 進捗イベントは呼び出し側で「結果を問わず1回だけ」emit するため、ここでは早期 return も
+    // ステータスを返して抜ける（return 漏れによる進捗カウント取りこぼしを構造的に防ぐ）。
+    let process_one = |item: &mut MediaInfo| -> ProgressStatus {
         {
             item.add_log(
                 LogLevel::Info,
@@ -534,7 +616,7 @@ fn process_media_inner(
                     );
                     item.add_log(LogLevel::Error, &msg);
                     errors.lock().unwrap().push(msg);
-                    return;
+                    return ProgressStatus::Error;
                 } else {
                     item.add_log(LogLevel::Info, "Backup created successfully");
                 }
@@ -558,7 +640,7 @@ fn process_media_inner(
                         );
                         item.add_log(LogLevel::Error, &msg);
                         errors.lock().unwrap().push(msg);
-                        return;
+                        return ProgressStatus::Error;
                     }
                 }
             } else {
@@ -577,7 +659,7 @@ fn process_media_inner(
                         );
                         item.add_log(LogLevel::Error, &msg);
                         errors.lock().unwrap().push(msg);
-                        return;
+                        return ProgressStatus::Error;
                     }
                 }
             };
@@ -699,13 +781,21 @@ fn process_media_inner(
                     }
 
                     *success_count.lock().unwrap() += 1;
+                    ProgressStatus::Completed
                 }
                 Err(msg) => {
                     item.add_log(LogLevel::Error, &msg);
                     errors.lock().unwrap().push(msg);
+                    ProgressStatus::Error
                 }
             }
         }
+    };
+
+    // 1ファイル処理 → 結果を問わず進捗を1回 emit する。
+    let processor = |item: &mut MediaInfo| {
+        let status = process_one(item);
+        emit_progress(item, status);
     };
 
     if options.parallel {
@@ -1015,5 +1105,145 @@ mod tests {
         );
         // subsec はミリ秒なので TZ で動かず保持される
         assert_eq!(item.derived.new_name, "2024-01-02_00-00-00-123.jpg");
+    }
+
+    // ---- 進捗（#4）----
+
+    /// フロント契約: ProgressEvent は camelCase キー（done/total/path/status）、
+    /// status は snake_case の "completed"/"error"。`types.ts` の ProgressEvent と一致。
+    #[test]
+    fn progress_event_wire_format() {
+        let ev = ProgressEvent {
+            done: 2,
+            total: 4,
+            path: "/in/IMG.jpg".to_string(),
+            status: ProgressStatus::Completed,
+        };
+        let value = serde_json::to_value(&ev).expect("serialize ProgressEvent");
+        let obj = value.as_object().expect("object");
+        let keys: BTreeSet<&str> = obj.keys().map(|k| k.as_str()).collect();
+        assert_eq!(
+            keys,
+            BTreeSet::from(["done", "total", "path", "status"]),
+            "ProgressEvent のキーは done/total/path/status（camelCase）のはず"
+        );
+        assert_eq!(obj["status"], serde_json::json!("completed"));
+
+        let err = ProgressEvent {
+            status: ProgressStatus::Error,
+            ..ev
+        };
+        let v = serde_json::to_value(&err).unwrap();
+        assert_eq!(v["status"], serde_json::json!("error"));
+    }
+
+    #[test]
+    fn progress_percent_basic_and_edges() {
+        assert_eq!(progress_percent(0, 4), 0);
+        assert_eq!(progress_percent(1, 4), 25);
+        assert_eq!(progress_percent(2, 4), 50);
+        assert_eq!(progress_percent(4, 4), 100);
+        // 端数は切り捨て: 1/3 = 33%
+        assert_eq!(progress_percent(1, 3), 33);
+        assert_eq!(progress_percent(2, 3), 66);
+        // total==0 は完了扱い（100）
+        assert_eq!(progress_percent(0, 0), 100);
+        // done > total でも 100 に丸める（防御的）
+        assert_eq!(progress_percent(5, 4), 100);
+    }
+
+    /// 進捗 done は 1..=total を1度ずつ網羅し、ファイル数ぶん emit される。
+    /// 並列処理でも到着順に関係なく到達点（done の集合）が一致することを検証する。
+    #[test]
+    fn progress_emits_once_per_file_covering_1_to_total() {
+        use std::collections::BTreeSet;
+        use std::sync::Mutex as StdMutex;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "photo_returns_progress_test_{}",
+            std::process::id()
+        ));
+        let in_dir = tmp.join("in");
+        let out_dir = tmp.join("out");
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&in_dir).unwrap();
+        fs::create_dir_all(&out_dir).unwrap();
+
+        // 入力ファイルを4つ用意（中身は何でもよい。日付なし→unsorted へコピーされる）。
+        let mut media = Vec::new();
+        for i in 0..4 {
+            let p = in_dir.join(format!("file{i}.jpg"));
+            fs::write(&p, b"x").unwrap();
+            media.push(tz_item(local_dt(2024, 1, 1, 0, 0, i), None, None, None));
+            // original_path をこのファイルに差し替える（コピー元が実在する必要がある）
+            let last = media.last_mut().unwrap();
+            last.source.original_path = p.clone();
+            last.source.file_name = format!("file{i}.jpg");
+            last.dates.date_taken = Some(local_dt(2024, 1, 1, 0, 0, i));
+        }
+
+        let events: Arc<StdMutex<Vec<ProgressEvent>>> = Arc::new(StdMutex::new(Vec::new()));
+        let events_cb = Arc::clone(&events);
+
+        let options = ProcessOptions {
+            parallel: true,
+            ..Default::default()
+        };
+        let result = process_media_with_list_progress(&mut media, &out_dir, &options, move |ev| {
+            events_cb.lock().unwrap().push(ev);
+        })
+        .unwrap();
+
+        let collected = events.lock().unwrap();
+        // ファイル数ぶん emit
+        assert_eq!(collected.len(), 4, "1ファイル1イベントのはず");
+        // total は全件
+        assert!(collected.iter().all(|e| e.total == 4));
+        // done は 1..=4 を1度ずつ網羅（並列でも採番が一意）
+        let dones: BTreeSet<usize> = collected.iter().map(|e| e.done).collect();
+        assert_eq!(dones, BTreeSet::from([1, 2, 3, 4]));
+        // 全件成功（実在ファイルを out へコピー）
+        assert!(collected
+            .iter()
+            .all(|e| e.status == ProgressStatus::Completed));
+        assert_eq!(result.processed_files, 4);
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// コピー元が存在しないファイルは Error ステータスで emit され、進捗カウントは進む。
+    #[test]
+    fn progress_emits_error_status_on_failure() {
+        let tmp = std::env::temp_dir().join(format!(
+            "photo_returns_progress_err_test_{}",
+            std::process::id()
+        ));
+        let out_dir = tmp.join("out");
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&out_dir).unwrap();
+
+        // 実在しないコピー元 → fs::copy が失敗し Error になる
+        let mut item = tz_item(local_dt(2024, 1, 1, 12, 0, 0), None, None, None);
+        item.source.original_path = tmp.join("does_not_exist.jpg");
+        let mut media = vec![item];
+
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let cb = Arc::clone(&captured);
+        let options = ProcessOptions {
+            parallel: false,
+            ..Default::default()
+        };
+        process_media_with_list_progress(&mut media, &out_dir, &options, move |ev| {
+            cb.lock().unwrap().push(ev);
+        })
+        .unwrap();
+
+        let evs = captured.lock().unwrap();
+        assert_eq!(evs.len(), 1);
+        assert_eq!(evs[0].status, ProgressStatus::Error);
+        assert_eq!(evs[0].done, 1);
+        assert_eq!(evs[0].total, 1);
+
+        let _ = fs::remove_dir_all(&tmp);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { invoke } from '@tauri-apps/api/core';
+import { invoke, Channel } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
 import {
   useReactTable,
@@ -9,8 +9,13 @@ import {
 } from '@tanstack/react-table';
 import './App.css';
 import { MOCK_ENABLED, mockMediaList, mockProcessResult } from './mock-data';
-import type { MediaInfo, ProcessResult } from './types';
-import { mergeProcessResults, selectRetryTargets } from './lib/processResults';
+import type { MediaInfo, ProcessResult, ProgressEvent } from './types';
+import {
+  mergeProcessResults,
+  selectRetryTargets,
+  applyProgressEvent,
+  markTargetsProcessing,
+} from './lib/processResults';
 import { MainLayout } from './components/MainLayout';
 import { useMediaTableColumns } from './hooks/useMediaTableColumns';
 import { getStorageValue, saveStorage } from './storage';
@@ -31,6 +36,12 @@ function App() {
   const [mediaList, setMediaList] = useState<MediaInfo[]>(MOCK_ENABLED ? mockMediaList : []);
   const [isScanning, setIsScanning] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
+  // 全体進捗（#4）: 処理中ファイル数 done/total と派生パーセント。処理開始でリセット、
+  // Channel 受信ごとに更新する。
+  const [progress, setProgress] = useState<{ done: number; total: number }>({
+    done: 0,
+    total: 0,
+  });
   const [processResult, setProcessResult] = useState<ProcessResult | null>(
     MOCK_ENABLED ? mockProcessResult : null
   );
@@ -271,6 +282,23 @@ function App() {
 
     setIsProcessing(true);
     setProcessResult(null);
+    // 全体進捗をリセット（total = 今回処理する件数。リトライ時は失敗ファイル数）。
+    setProgress({ done: 0, total: targets.length });
+    // 対象行を「処理中」に。対象外（完了済みなど）は据え置く。
+    setMediaList((prev) => markTargetsProcessing(prev, targets));
+
+    // ファイル1件完了ごとにバックエンドから届く進捗イベントを受ける Channel（#4）。
+    // onmessage 内では setMediaList の関数更新形を使い、stale closure（古い mediaList の
+    // キャプチャ）を避ける。Channel は invoke 解決後に GC されるので明示解除は不要。
+    const onProgress = new Channel<ProgressEvent>();
+    onProgress.onmessage = (event) => {
+      // 該当行のステータス／進捗をライブ更新（new_path/logs は完了後の最終マージで確定）。
+      setMediaList((prev) => applyProgressEvent(prev, event));
+      // 全体進捗はイベントの done を採用（並列でも単調増加・1..=total を網羅）。
+      setProgress((prev) =>
+        event.done > prev.done ? { done: event.done, total: event.total } : prev
+      );
+    };
 
     try {
       // backend は渡した media_list だけを処理し、各項目の status は見ない。
@@ -282,17 +310,22 @@ function App() {
         parallel: true,
         includeVideos: true,
         cleanupTemp: true,
+        onProgress,
       });
 
       setProcessResult(result);
 
       // 処理結果を反映。今回処理した targets のみ更新し、対象外（完了済みなど）は
-      // 据え置く（リトライで完了済みを再処理・誤 error 化しない）。
+      // 据え置く（リトライで完了済みを再処理・誤 error 化しない）。new_path/logs を確定値で
+      // 上書きし、ライブ進捗の暫定 status を最終結果へ揃える。
       setMediaList((prev) => mergeProcessResults(prev, targets, result.media));
     } catch (error) {
       console.error('Process error:', error);
       alert(`Process error: ${error}`);
     } finally {
+      // listener を解除して以後の送信を無視（処理失敗時に行が processing のまま残らないよう、
+      // 念のため onmessage を外す）。
+      onProgress.onmessage = () => {};
       setIsProcessing(false);
     }
   };
@@ -370,6 +403,8 @@ function App() {
       onProcessMedia={processMedia}
       onRetryFailed={retryFailedFiles}
       isProcessing={isProcessing}
+      progressDone={progress.done}
+      progressTotal={progress.total}
       mediaList={mediaList}
       processResult={processResult}
       table={table}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -289,7 +289,7 @@ function App() {
 
     // ファイル1件完了ごとにバックエンドから届く進捗イベントを受ける Channel（#4）。
     // onmessage 内では setMediaList の関数更新形を使い、stale closure（古い mediaList の
-    // キャプチャ）を避ける。Channel は invoke 解決後に GC されるので明示解除は不要。
+    // キャプチャ）を避ける。invoke 解決後は finally で listener を解除する。
     const onProgress = new Channel<ProgressEvent>();
     onProgress.onmessage = (event) => {
       // 該当行のステータス／進捗をライブ更新（new_path/logs は完了後の最終マージで確定）。
@@ -322,9 +322,15 @@ function App() {
     } catch (error) {
       console.error('Process error:', error);
       alert(`Process error: ${error}`);
+      // invoke 自体が失敗した場合（IPC エラー等）、processing のまま固まった対象行を
+      // error に落として復帰可能にする（Retry Failed の対象に乗る）。
+      setMediaList((prev) =>
+        prev.map((item) =>
+          item.status === 'processing' ? { ...item, status: 'error' as const, progress: 0 } : item
+        )
+      );
     } finally {
-      // listener を解除して以後の送信を無視（処理失敗時に行が processing のまま残らないよう、
-      // 念のため onmessage を外す）。
+      // listener を解除して以後の送信を無視する。
       onProgress.onmessage = () => {};
       setIsProcessing(false);
     }

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -9,6 +9,7 @@ import { ProcessingFlow } from './ProcessingFlow';
 import { LightBox } from './LightBox';
 import { DirectorySelection } from './DirectorySelection';
 import { DefaultSettings } from './DefaultSettings';
+import { progressPercent } from '../lib/processResults';
 
 interface MainLayoutProps {
   isDark: boolean;
@@ -34,6 +35,8 @@ interface MainLayoutProps {
   onProcessMedia: () => void;
   onRetryFailed: () => void;
   isProcessing: boolean;
+  progressDone: number;
+  progressTotal: number;
   mediaList: MediaInfo[];
   processResult: ProcessResult | null;
   table: Table<MediaInfo>;
@@ -69,6 +72,8 @@ export function MainLayout({
   onProcessMedia,
   onRetryFailed,
   isProcessing,
+  progressDone,
+  progressTotal,
   mediaList,
   processResult,
   table,
@@ -156,6 +161,44 @@ export function MainLayout({
                 {isProcessing ? 'PROCESSING...' : 'PROCESS & RENAME'}
               </button>
             </div>
+
+            {/* Overall progress bar — live during processing (#4) */}
+            {isProcessing && progressTotal > 0 && (
+              <div className="flex flex-col gap-1.5 pt-1">
+                <div className="flex items-center justify-between">
+                  <span
+                    className="led-display text-xs"
+                    style={{ color: '#44ff44', letterSpacing: '0.1em' }}
+                  >
+                    PROCESSING {String(progressDone).padStart(4, '0')} /{' '}
+                    {String(progressTotal).padStart(4, '0')}
+                  </span>
+                  <span
+                    className="led-display text-xs"
+                    style={{ color: '#44ff44', letterSpacing: '0.1em' }}
+                  >
+                    {progressPercent(progressDone, progressTotal)}%
+                  </span>
+                </div>
+                <div
+                  className="h-2 w-full overflow-hidden rounded-sm"
+                  style={{ background: '#0a0a0a', border: '1px solid #222' }}
+                  role="progressbar"
+                  aria-valuenow={progressPercent(progressDone, progressTotal)}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                >
+                  <div
+                    className="h-full transition-all duration-200"
+                    style={{
+                      width: `${progressPercent(progressDone, progressTotal)}%`,
+                      background: 'linear-gradient(90deg, #2a8a2a, #44ff44)',
+                      boxShadow: '0 0 6px rgba(68,255,68,0.6)',
+                    }}
+                  />
+                </div>
+              </div>
+            )}
           </div>
         </section>
 

--- a/src/lib/processResults.test.ts
+++ b/src/lib/processResults.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import type { MediaInfo, LogEntry } from '../types';
-import { mergeProcessResults, normalizePathForCompare, selectRetryTargets } from './processResults';
+import type { MediaInfo, LogEntry, ProgressEvent } from '../types';
+import {
+  mergeProcessResults,
+  normalizePathForCompare,
+  selectRetryTargets,
+  progressPercent,
+  applyProgressEvent,
+  markTargetsProcessing,
+} from './processResults';
 
 const log = (message: string): LogEntry => ({
   timestamp: '2026-01-01T00:00:00Z',
@@ -119,5 +126,99 @@ describe('mergeProcessResults', () => {
     const merged = mergeProcessResults([item], [item], resultMedia);
     expect(merged[0].status).toBe('completed');
     expect(merged[0].new_path).toBe('C:/out/x.jpg');
+  });
+});
+
+describe('progressPercent', () => {
+  it('done/total を 0-100 整数で返し、端数は切り捨てる', () => {
+    expect(progressPercent(0, 4)).toBe(0);
+    expect(progressPercent(1, 4)).toBe(25);
+    expect(progressPercent(4, 4)).toBe(100);
+    expect(progressPercent(1, 3)).toBe(33);
+    expect(progressPercent(2, 3)).toBe(66);
+  });
+
+  it('total<=0 は完了扱いで 100、done>total は 100 に丸める', () => {
+    expect(progressPercent(0, 0)).toBe(100);
+    expect(progressPercent(3, 0)).toBe(100);
+    expect(progressPercent(5, 4)).toBe(100);
+  });
+
+  it('バックエンド progress_percent と同じ値（同式）', () => {
+    // Rust 側 progress_percent と一致することを代表点で固定
+    for (const [d, t, p] of [
+      [0, 4, 0],
+      [2, 4, 50],
+      [1, 3, 33],
+      [2, 3, 66],
+    ] as const) {
+      expect(progressPercent(d, t)).toBe(p);
+    }
+  });
+});
+
+describe('applyProgressEvent', () => {
+  const ev = (path: string, status: 'completed' | 'error', done = 1, total = 1): ProgressEvent => ({
+    done,
+    total,
+    path,
+    status,
+  });
+
+  it('completed イベントで該当行を completed/progress=100 にする', () => {
+    const a = media('/a.jpg', { status: 'processing', progress: 0 });
+    const b = media('/b.jpg', { status: 'processing', progress: 0 });
+    const next = applyProgressEvent([a, b], ev('/a.jpg', 'completed'));
+    expect(next[0].status).toBe('completed');
+    expect(next[0].progress).toBe(100);
+    // 他の行は参照ごと不変
+    expect(next[1]).toBe(b);
+  });
+
+  it('error イベントで該当行を error/progress=0 にする（失敗で100%にしない）', () => {
+    const a = media('/a.jpg', { status: 'processing', progress: 0 });
+    const next = applyProgressEvent([a], ev('/a.jpg', 'error'));
+    expect(next[0].status).toBe('error');
+    expect(next[0].progress).toBe(0);
+  });
+
+  it('一致行が無ければ配列を参照ごと据え置く（無駄な再レンダー回避）', () => {
+    const list = [media('/a.jpg', { status: 'processing' })];
+    const next = applyProgressEvent(list, ev('/zzz.jpg', 'completed'));
+    expect(next).toBe(list);
+  });
+
+  it('プラットフォーム差のあるパスでも一致させる', () => {
+    const a = media('C:\\photos\\x.jpg', { status: 'processing' });
+    const next = applyProgressEvent([a], ev('C:/photos/x.jpg', 'completed'));
+    expect(next[0].status).toBe('completed');
+  });
+
+  it('new_path / logs は触らない（ライブ表示のみ。最終確定は merge が担う）', () => {
+    const a = media('/a.jpg', { status: 'processing', new_path: '', logs: [log('scan')] });
+    const next = applyProgressEvent([a], ev('/a.jpg', 'completed'));
+    expect(next[0].new_path).toBe('');
+    expect(next[0].logs.map((l) => l.message)).toEqual(['scan']);
+  });
+});
+
+describe('markTargetsProcessing', () => {
+  it('対象行のみ processing/progress=0 にし、対象外は参照ごと据え置く', () => {
+    const a = media('/a.jpg', { status: 'completed', progress: 100, new_path: '/out/a.jpg' });
+    const b = media('/b.jpg', { status: 'error', progress: 0 });
+    const c = media('/c.jpg', { status: 'pending' });
+    const next = markTargetsProcessing([a, b, c], [b]);
+    // 対象外は不変参照
+    expect(next[0]).toBe(a);
+    expect(next[2]).toBe(c);
+    // 対象は processing にリセット
+    expect(next[1].status).toBe('processing');
+    expect(next[1].progress).toBe(0);
+  });
+
+  it('対象が空なら全行を参照ごと据え置く', () => {
+    const a = media('/a.jpg', { status: 'completed' });
+    const next = markTargetsProcessing([a], []);
+    expect(next[0]).toBe(a);
   });
 });

--- a/src/lib/processResults.ts
+++ b/src/lib/processResults.ts
@@ -1,4 +1,57 @@
-import type { MediaInfo } from '../types';
+import type { MediaInfo, ProgressEvent } from '../types';
+
+/**
+ * done/total から進捗パーセント（0-100, 整数）を求める。
+ * `total === 0` は完了扱いで 100。端数は切り捨て、`done >= total` は 100 に丸める。
+ * バックエンド（Rust `progress_percent`）と同じ式。
+ */
+export function progressPercent(done: number, total: number): number {
+  if (total <= 0) return 100;
+  const d = Math.min(done, total);
+  return Math.floor((d * 100) / total);
+}
+
+/**
+ * 1件分の進捗イベントを全リストにマージする（#4）。
+ *
+ * `event.path`（バックエンドの original_path）に一致する1行だけを更新する。完了したファイルは
+ * status を completed / error にし、progress を成否で出し分ける（成功=100、失敗=0。失敗で 100%
+ * にすると「失敗なのに100%」になるため）。一致しない行は同一参照のまま据え置く（再レンダー最小化）。
+ *
+ * 注: ここでは `new_path` / `logs` は触らない（それらは処理完了後の `mergeProcessResults` が
+ * 確定値で上書きする）。本関数は処理中のライブ表示のみを担う。
+ */
+export function applyProgressEvent(fullList: MediaInfo[], event: ProgressEvent): MediaInfo[] {
+  const key = normalizePathForCompare(event.path);
+  let changed = false;
+  const next = fullList.map((item) => {
+    if (normalizePathForCompare(item.original_path) !== key) {
+      return item;
+    }
+    changed = true;
+    return {
+      ...item,
+      status: event.status === 'completed' ? ('completed' as const) : ('error' as const),
+      progress: event.status === 'completed' ? 100 : 0,
+    };
+  });
+  // 一致行が無ければ参照ごと不変を返す（無駄な再レンダーを避ける）
+  return changed ? next : fullList;
+}
+
+/**
+ * 処理対象 targets を「処理中」状態にリセットする（invoke 直前に呼ぶ、#4）。
+ * 対象行だけ status=processing / progress=0 にし、対象外は据え置く。
+ */
+export function markTargetsProcessing(fullList: MediaInfo[], targets: MediaInfo[]): MediaInfo[] {
+  const targetPaths = new Set(targets.map((t) => normalizePathForCompare(t.original_path)));
+  return fullList.map((item) => {
+    if (!targetPaths.has(normalizePathForCompare(item.original_path))) {
+      return item;
+    }
+    return { ...item, status: 'processing' as const, progress: 0 };
+  });
+}
 
 /**
  * プラットフォーム依存のパス区切り（Windows の `\\` と POSIX の `/`）を吸収して

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,3 +48,12 @@ export interface ProcessResult {
   media: MediaInfo[];
   errors: string[];
 }
+
+// ファイル1件完了ごとにバックエンド（Rust）から Channel 経由で届く進捗イベント（#4）。
+// Rust 側 `ProgressEvent`（serde rename_all = "camelCase"）と対応する。
+export interface ProgressEvent {
+  done: number; // 完了済み件数（1..=total、このイベント分を含む）
+  total: number; // 今回処理する総件数（リトライ時は失敗ファイル数）
+  path: string; // 完了したファイルの original_path（行引き当てキー）
+  status: 'completed' | 'error'; // Rust 側 ProgressStatus（snake_case）
+}


### PR DESCRIPTION
## 概要

進捗表示のフェイク（0% → 100%）を撤去し、Tauri 2 の `tauri::ipc::Channel<ProgressEvent>` でファイル1件完了ごとにリアルタイム進捗を送るようにした。Closes は付けず、実機目視まで #4 は open のまま残す（下記）。

## 設計（Channel 方式）

- **backend (`photo_core/mod.rs`)**
  - `ProgressEvent { done, total, path, status }`（`done` は完了済み件数 1..=total、`status` は `completed`/`error`）を1ファイル処理完了ごとに1回 emit。
  - 純関数 `progress_percent(done, total)`（0-100整数・端数切り捨て・total==0→100）を追加。フロントの `progressPercent` と同式。
  - 並列(rayon)でも `done` を `Arc<AtomicUsize>` の `fetch_add` で採番 → 到着順に関係なく 1..=total を1度ずつ網羅（取りこぼし・重複なし）。
  - 処理本体を `process_one(item) -> ProgressStatus` に切り出し、早期 return（バックアップ/ディレクトリ作成失敗）もステータスを返して抜けることで「1ファイル1イベント」を構造的に保証。
- **command (`lib.rs`)**: `process_media_with_settings(..., on_progress: Channel<ProgressEvent>)`。送信失敗は処理継続を妨げないため握り潰し。
- **frontend (`App.tsx` / `lib/processResults.ts` / `MainLayout.tsx`)**
  - invoke 時に `new Channel<ProgressEvent>()` を渡し、`onmessage` で `applyProgressEvent` により該当行を更新。`setMediaList` は関数更新形で **stale closure** 回避。
  - invoke 直前に `markTargetsProcessing` で対象行を `processing`/`progress=0` にリセット、`finally` で `onmessage` を解除。
  - 全体進捗バーを `MainLayout` に表示。
  - 処理完了後の `new_path`/`logs` 等の確定値は従来どおり `mergeProcessResults`（#6）で上書き。ライブ進捗は表示のみで `new_path`/`logs` を触らない。
  - **リトライ**（失敗ファイルのみ）でも `total = targets.length` なので進捗が正しく出る。

## テスト

- **Rust（cargo test, 計49件 green）**: `progress_percent` 境界、進捗 emit が 1..=total を1度ずつ網羅、失敗時 error status、ProgressEvent の wire format（camelCase キー + status snake_case）。
- **TS（vitest, 計17件 green）**: `progressPercent`（Rust と同値固定）、`applyProgressEvent`（completed/error/不一致据え置き/パス差吸収/new_path・logs 不変）、`markTargetsProcessing`。

## 検証結果（ローカル）

- `cargo test`: ok 49 passed
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- `npm run build`（tsc + vite）: ok
- `npm run lint`（eslint）: clean
- `npm test`（vitest）: 17 passed
- `npm run format:check`（prettier）: clean

## 実機検証（#4 を open のままにする理由）

CLAUDE.md ルール7（完了判定は実機での仕様達成）に従い、GUI 実機で進捗バーが 0→100 へ滑らかに動くことの目視は Tauri デスクトップ環境が必要で本作業では実施できていない。よって **本 PR はマージしてよいが、#4 は close せず open のまま残し**、実機確認手順を #4 にコメントする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)