### PR TITLE
fix: main のビルドエラーと fmt 違反を解消する (#35)

### DIFF
--- a/src-tauri/src/bin/audit.rs
+++ b/src-tauri/src/bin/audit.rs
@@ -42,12 +42,13 @@ fn main() {
         timezone_offset: None,
         cleanup_temp: false,
         auto_correct_orientation: false,
+        exclude_system_artifacts: true,
     };
 
     for input in args.iter().skip(1) {
         let input_dir = PathBuf::from(input);
         let media = match photo_core::scan_media(&input_dir, &options) {
-            Ok(media) => media,
+            Ok(outcome) => outcome.media,
             Err(err) => {
                 eprintln!("scan failed for {}: {err}", input_dir.display());
                 continue;

--- a/src-tauri/src/bin/filelist_batch.rs
+++ b/src-tauri/src/bin/filelist_batch.rs
@@ -122,6 +122,7 @@ fn main() {
         timezone_offset: None,
         cleanup_temp: true,
         auto_correct_orientation: false,
+        exclude_system_artifacts: true,
     };
 
     let selected_file = File::create(&selected_path).unwrap_or_else(|err| {
@@ -142,7 +143,7 @@ fn main() {
     for input_dir in &input_dirs {
         eprintln!("Scanning {}", input_dir.display());
         let media = match photo_core::scan_media(input_dir, &options) {
-            Ok(media) => media,
+            Ok(outcome) => outcome.media,
             Err(err) => {
                 eprintln!("scan failed for {}: {err}", input_dir.display());
                 continue;

--- a/src-tauri/src/bin/safe_batch.rs
+++ b/src-tauri/src/bin/safe_batch.rs
@@ -40,7 +40,9 @@ fn skip_reason(item: &MediaInfo) -> Option<&'static str> {
         return Some("burst_or_derived_frame");
     }
     match item.source.media_type {
-        MediaType::Photo if item.dates.date_source != DateSource::Exif => Some("photo_without_exif"),
+        MediaType::Photo if item.dates.date_source != DateSource::Exif => {
+            Some("photo_without_exif")
+        }
         MediaType::Video if item.dates.date_source != DateSource::QuickTime => {
             Some("video_without_quicktime")
         }

--- a/src-tauri/src/bin/safe_batch.rs
+++ b/src-tauri/src/bin/safe_batch.rs
@@ -97,6 +97,7 @@ fn main() {
         timezone_offset: None,
         cleanup_temp: true,
         auto_correct_orientation: false,
+        exclude_system_artifacts: true,
     };
 
     let skipped_file = File::create(&skipped_path).unwrap_or_else(|err| {
@@ -117,7 +118,7 @@ fn main() {
     for input_dir in &input_dirs {
         eprintln!("Scanning {}", input_dir.display());
         let media = match photo_core::scan_media(input_dir, &options) {
-            Ok(media) => media,
+            Ok(outcome) => outcome.media,
             Err(err) => {
                 eprintln!("scan failed for {}: {err}", input_dir.display());
                 continue;


### PR DESCRIPTION
## 関連 Issue

closes #35

## 背景

`f1b728c "update."` 以降、**main がビルドできず CI が失敗していた**。

`f1b728c` で追加された `audit.rs` / `filelist_batch.rs` / `safe_batch.rs` の3バイナリが、**PR #32（Issue #28・システム生成物の除外）マージ前の API** に対して書かれていた。

```
error[E0063]: missing field `exclude_system_artifacts` in initializer of `ProcessOptions`
error[E0277]: `ScanOutcome` is not an iterator
error[E0599]: no method named `len` found for struct `ScanOutcome`
```

CI は `cargo fmt --check`（`safe_batch.rs:40`）で先に止まっていたため、ビルドエラーまで到達していなかった。

## 変更内容

`cli.rs` が同じ API 変更にどう追従しているかに合わせ、3バイナリに機械的な追従のみを行った。

- `ProcessOptions` の初期化に `exclude_system_artifacts: true` を追加（`Default` と同じ値）
- `scan_media(...)` の戻り値を `Ok(media) => media` から `Ok(outcome) => outcome.media` に変更
- `cargo fmt` を通す（`safe_batch.rs`）

**3バイナリのロジック・出力フォーマットは一切変更していない。** 写真整理の実作業に使うツールのため、挙動を変えないことを最優先した。

### `exclude_system_artifacts` を `true` にした理由
3本とも写真整理の棚卸し・選抜処理用途であり、システム生成物（`.trashed-*` 等）を数えたいわけではないと判断した。**「Takeout にゴミがどれだけ混じっているかを数えたい」意図であれば `false` が正しい**ので、その場合は変更する。

## 検証

```
cargo fmt --check                          OK
cargo clippy --all-targets -- -D warnings  OK（警告0件）
cargo test                                 OK（lib 64 + e2e 13）
npm run lint / format:check / build / test OK（36件）
```

## 再発防止（別途要検討）

- `safe_batch.rs` が未整形のまま入っていたのは、pre-commit hook（Husky + lint-staged で `cargo fmt` が走る設定）が効いていないことを示唆する。`--no-verify` の使用、別マシンでの hook 未インストール、`core.hooksPath` の破損のいずれかが疑われる
- CI が `cargo fmt --check` で停止し、その先のビルドエラーが1回の実行で見えなかった。fmt チェックを後段に回すか、失敗しても後続を実行する構成にすれば全ての失敗が一度に分かる
