### PR TITLE
fix: pre-commit hook の再ステージ漏れと CI の早期終了を直す (#38, #39)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  check:
+  frontend:
     runs-on: ubuntu-latest
 
     steps:
@@ -20,13 +20,24 @@ jobs:
           cache: 'npm'
 
       - name: Install frontend dependencies
+        id: npm_ci
         run: npm ci
 
+      # build と test は互いに依存しない（vitest はビルド成果物を使わない）ため、
+      # 一方が失敗してももう一方を実行し、両方の結果を1回のCI実行で見えるようにする。
       - name: Build frontend (tsc + vite)
+        if: always() && steps.npm_ci.outcome == 'success'
         run: npm run build
 
       - name: Frontend tests (vitest)
+        if: always() && steps.npm_ci.outcome == 'success'
         run: npm test
+
+  rust:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -39,6 +50,7 @@ jobs:
           workspaces: './src-tauri -> target'
 
       - name: Install system dependencies for Tauri
+        id: system_deps
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -53,18 +65,27 @@ jobs:
       # turbojpeg-sys は同梱 libjpeg-turbo(>=3.0) を cmake で vendor ビルドする。
       # SIMD(require-simd)に nasm が必須。cmake/gcc は runner に既存。
 
+      # fmt / clippy / check は互いに独立した判定なので、どれか1つが失敗しても
+      # 残りを実行し、1回のCI実行で全ての失敗を見せる（fmt失敗がビルドエラーを
+      # 隠さないようにする。#39 の原因）。test だけは check の成功に依存させる
+      # （ビルドが通らない状態で test を走らせても新しい情報は増えない）。
       - name: Rust format check
+        if: always() && steps.system_deps.outcome == 'success'
         working-directory: src-tauri
         run: cargo fmt --check
 
       - name: Rust clippy
+        if: always() && steps.system_deps.outcome == 'success'
         working-directory: src-tauri
         run: cargo clippy -- -D warnings
 
       - name: Rust check
+        id: rust_check
+        if: always() && steps.system_deps.outcome == 'success'
         working-directory: src-tauri
         run: cargo check
 
       - name: Rust test
+        if: always() && steps.rust_check.outcome == 'success'
         working-directory: src-tauri
         run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,9 @@ jobs:
       - name: Rust clippy
         if: always() && steps.system_deps.outcome == 'success'
         working-directory: src-tauri
-        run: cargo clippy -- -D warnings
+        # --all-targets でテスト・bin ターゲットまで検査する。
+        # これが無いと tests/ と src/bin/ の警告を CI が見逃す。
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Rust check
         id: rust_check

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
 npx lint-staged
-cd src-tauri && cargo fmt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ cd src-tauri && cargo test  # Rust tests
 ## Key Conventions
 
 - Pre-commit hooks: Husky + lint-staged (ESLint + Prettier for TS, rustfmt for Rust)。clippy はビルドを伴い遅いため pre-commit では実行せず CI に任せる
+- **`git worktree` で作業ディレクトリを作ったら、そこで最初に `npm run prepare` を実行する。** husky v9 は hooks を `.husky/_`（gitignore 対象、`prepare`=`husky` コマンドが生成）に向けており、worktree にはこのディレクトリが存在しない。`node_modules` を共有クローンから symlink しただけでは `.husky/_` は生成されない（`prepare` は `npm install`/`npm ci` のライフサイクルでしか走らない）。この状態では git は pre-commit hook を**エラーも警告も出さずに黙って無視する**ため、rustfmt/lint-staged が一切走らず、未整形の Rust コードがそのままコミットできてしまう（#38 の「未整形コミット」を起こしうる別経路。忘れると気づかずに再発する）
 - `chrono` requires `serde` feature for DateTime serialization
 - `kamadak-exif` is imported as `exif`
 - `img-parts` requires `use` for `ImageEXIF` trait

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ cd src-tauri && cargo test  # Rust tests
 
 ## CI/CD
 
-- **CI**: `.github/workflows/ci.yml` — push/PR to main triggers `npm run build` / `npm test` (vitest) / `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo check` / `cargo test`
+- **CI**: `.github/workflows/ci.yml` — push/PR to main は `frontend` job（`npm run build` / `npm test`）と `rust` job（`cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo check` / `cargo test`）を並列実行。各 job 内でも独立して判定できるステップ（frontendのbuildとtest、rustのfmt/clippy/check）は互いの失敗に関わらず全て実行され、1回のCI実行で全ての失敗が見える（test だけは check の成功に依存）。いずれか1つでも失敗すれば job・CI全体が失敗になる
 - **Release**: `.github/workflows/release.yml` — manual dispatch or tag `v*`, 3-OS matrix (macOS/Linux/Windows), tauri-action, draft release
 - **Pre-commit**: Husky + lint-staged（`eslint --fix` + `prettier` for TS/JS、`prettier` for JSON/CSS/MD、`rustfmt --edition 2021` for Rust）。整形結果は lint-staged が自動で再ステージする。clippy は実行しない
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ cd src-tauri && cargo test  # Rust tests
 
 ## Key Conventions
 
-- Pre-commit hooks: Husky + lint-staged (ESLint + Prettier for TS, rustfmt + clippy for Rust)
+- Pre-commit hooks: Husky + lint-staged (ESLint + Prettier for TS, rustfmt for Rust)。clippy はビルドを伴い遅いため pre-commit では実行せず CI に任せる
 - `chrono` requires `serde` feature for DateTime serialization
 - `kamadak-exif` is imported as `exif`
 - `img-parts` requires `use` for `ImageEXIF` trait
@@ -54,7 +54,7 @@ cd src-tauri && cargo test  # Rust tests
 
 - **CI**: `.github/workflows/ci.yml` — push/PR to main triggers `npm run build` / `npm test` (vitest) / `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo check` / `cargo test`
 - **Release**: `.github/workflows/release.yml` — manual dispatch or tag `v*`, 3-OS matrix (macOS/Linux/Windows), tauri-action, draft release
-- **Pre-commit**: Husky + lint-staged (`eslint --fix` + `prettier` for TS/JS, `prettier` for JSON/CSS/MD) + `cargo fmt`
+- **Pre-commit**: Husky + lint-staged（`eslint --fix` + `prettier` for TS/JS、`prettier` for JSON/CSS/MD、`rustfmt --edition 2021` for Rust）。整形結果は lint-staged が自動で再ステージする。clippy は実行しない
 
 ## Design Decisions
 

--- a/LINT_SETUP.md
+++ b/LINT_SETUP.md
@@ -97,7 +97,7 @@ git commit -m "test commit"
 
 fmt / clippy / check は互いに独立した判定のため、どれか1つが失敗しても残りは実行され、1回のCI実行で全ての失敗が見えます（fmt失敗がビルドエラーを隠さないようにするための構成）。
 
-### リリースビルド時のチェック (.github/workflows/build-release.yml)
+### リリースビルド時のチェック (.github/workflows/release.yml)
 
 リリースビルド時にも同様のチェックが実行されます。
 

--- a/LINT_SETUP.md
+++ b/LINT_SETUP.md
@@ -148,6 +148,16 @@ fmt / clippy / check は互いに独立した判定のため、どれか1つが�
 npm run prepare
 ```
 
+husky v9 は `core.hooksPath` を `.husky/_` に向けるが、この `_` ディレクトリは
+`npm run prepare` が生成するもので **gitignore 対象**。存在しない場合、git は
+pre-commit フックを**エラーも警告も出さずに黙って無視する**（コミットは普通に成功し、
+rustfmt も lint-staged も走らない）。
+
+特に **`git worktree` で作った作業ディレクトリでは必ずこの状態になる**。
+`node_modules` を共有クローンから symlink しただけでは足りない（`prepare` は
+`npm install` / `npm ci` のライフサイクルでしか走らない）。worktree を作ったら
+最初に `npm run prepare` を実行すること。
+
 ### ESLint エラー
 
 ```bash

--- a/LINT_SETUP.md
+++ b/LINT_SETUP.md
@@ -59,8 +59,9 @@ npm run lint && npm run format:check && npm run lint:rust && npm run format:rust
 1. **Prettier** で自動フォーマット
 
 ### Rust ファイル (.rs)
-1. **rustfmt** で自動フォーマット
-2. **clippy** でlintチェック
+1. **rustfmt** で自動フォーマット（整形結果は lint-staged が自動で再ステージする）
+
+clippy は pre-commit では実行しない（ビルドを伴い遅いため）。CI 側でのみチェックする。
 
 ### 動作確認
 
@@ -80,13 +81,21 @@ git commit -m "test commit"
 
 ### PR/Push 時のチェック (.github/workflows/ci.yml)
 
-`main` ブランチへの Push または PR 時に以下が実行されます：
+`main` ブランチへの Push または PR 時に、`frontend` job と `rust` job が並列で実行されます。どちらか一方でも失敗すれば CI 全体が失敗になります。
 
-1. フロントエンド lint チェック
-2. フロントエンド フォーマットチェック
-3. Rust フォーマットチェック
-4. Rust lint チェック（警告のみ）
-5. TypeScript ビルドチェック
+**frontend job:**
+1. `npm run build`（tsc + vite）
+2. `npm test`（vitest）
+
+ビルドとテストは互いに依存しないため、一方が失敗してももう一方は実行され、1回のCI実行で両方の結果が見えます。
+
+**rust job:**
+1. `cargo fmt --check`
+2. `cargo clippy -- -D warnings`（警告はエラー扱い）
+3. `cargo check`
+4. `cargo test`（`cargo check` が成功した場合のみ）
+
+fmt / clippy / check は互いに独立した判定のため、どれか1つが失敗しても残りは実行され、1回のCI実行で全ての失敗が見えます（fmt失敗がビルドエラーを隠さないようにするための構成）。
 
 ### リリースビルド時のチェック (.github/workflows/build-release.yml)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -501,7 +501,7 @@ npm run format:rust:check  # rustfmt チェック
 リリースはドラフトとして作成されるため、公開前に内容を確認・編集できます。
 
 **設定ファイル:**
-- `.github/workflows/build-release.yml` - ビルドワークフロー定義
+- `.github/workflows/release.yml` - リリースビルドワークフロー定義
 - `src-tauri/tauri.conf.json` - アプリ設定（バージョン、識別子等）
 
 ## 既知の問題と解決策

--- a/docs/development.md
+++ b/docs/development.md
@@ -476,9 +476,10 @@ npm run format:rust:check  # rustfmt チェック
 ```
 
 **Pre-commit フック:**
-- **Husky + lint-staged** によりコミット時に自動実行
+- **Husky + lint-staged** によりコミット時に自動実行（整形結果は lint-staged が自動で再ステージする）
 - TypeScript/React: ESLint + Prettier
-- Rust: rustfmt + clippy
+- Rust: rustfmt（clippy はビルドを伴い遅いため pre-commit では実行せず CI に任せる）
+- `git worktree` で作った作業ディレクトリでは `npm run prepare` を実行しないと hook が無言で無効になる（詳細は `CLAUDE.md`）
 - 詳細は `LINT_SETUP.md` を参照
 
 ### ビルド & リリース

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     ],
     "*.{json,css,md}": [
       "prettier --write"
+    ],
+    "src-tauri/**/*.rs": [
+      "rustfmt --edition 2021"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
## 関連 Issue

closes #38
closes #39

## 背景

`f1b728c` で未整形の Rust が main に入り、しかも CI が `cargo fmt --check` で停止したため**その先のビルドエラー3件が見えず**、修正が2往復になった（Issue #35）。原因は2つあり、どちらも開発フローの穴だった。

## #38: pre-commit hook の `cargo fmt` が再ステージされない

### 原因
```sh
# 修正前の .husky/pre-commit
npx lint-staged
cd src-tauri && cargo fmt      ← 整形するが git add していない
```

`cargo fmt` は**ステージング後に**走り、結果を再ステージしていなかった。そのため:

1. 未整形の `.rs` を `git add`
2. hook が `cargo fmt` を実行 → **ワーキングツリー上のファイルだけ**整形される
3. コミットされるのは**インデックスにある未整形版**
4. コミット後、整形差分が未ステージの変更として残る

`--no-verify` でも `core.hooksPath` の破損でもなく、**hook 自体のバグ**。

### 修正
`lint-staged` に Rust を登録した。

```json
"src-tauri/**/*.rs": ["rustfmt --edition 2021"]
```

**lint-staged は自分が変更したファイルだけを自動で再ステージする**ため、これが本来の直し方。`.husky/pre-commit` に `git add` を手で足す方式は採らなかった — `git add -u src-tauri` のような書き方だと、**ユーザーが意図的にステージから外した変更まで巻き込む**危険があるため。

`cargo fmt` ではなく `rustfmt` を直接使っているのは、lint-staged がステージ済みファイルのパスを引数で渡すため。`--edition 2021` は `src-tauri/Cargo.toml` と `rustfmt.toml` に合わせた。

**clippy は pre-commit に入れていない**（ビルドを伴い遅く、コミットのたびに数分待たされる）。CI に任せる方針とし、`CLAUDE.md` の「rustfmt + clippy for Rust」という記述の方を実態に合わせた。

### 実動作で検証済み
机上で終わらせず、**わざと未整形の Rust ファイルを作ってコミットし、整形された状態でコミットされること**を確認した（検証用コミットは `git reset` で取り消し済み）。

## #38 の副産物: git worktree では hook が黙って無効になる

検証中に判明した重要な事実。

**`git worktree` で作った作業ディレクトリでは husky の hook が一切走らない。** husky v9 は `core.hooksPath` を `.husky/_` に向けるが、この `_` は `npm run prepare` が生成する **gitignore 対象**のディレクトリで、worktree には存在しない。git は hook を見つけられず**エラーも警告も出さずに素通りする**。

`node_modules` を共有クローンから symlink しただけでは足りない（`prepare` は npm install/ci のライフサイクルでしか走らない）。

Issue #38 の「未整形コミット」を起こしうる**別経路**なので、`CLAUDE.md` と `docs/development.md` に明記した。

## #39: CI が fmt で早期終了し1回の実行で全ての失敗が見えない

`.github/workflows/ci.yml` を2ジョブに分割した。

- **`frontend`**: `npm ci` の後、`build` と `test` が互いに独立して実行される（vitest は vite build の出力に依存しないため）
- **`rust`**: セットアップ（toolchain / キャッシュ / system deps）は直列のまま、`fmt` / `clippy` / `check` が**互いに独立**して実行される。`test` は `check` 成功時のみ（コンパイルが通らない状態でテストを走らせても新しい情報が得られないため）

### 判断理由
frontend と rust は共有するセットアップが無いので**ジョブ分割**が無料で、ウォールクロックも稼げる。一方 fmt / clippy / check は高価なセットアップを共有するため3ジョブに割ると同じ準備を3回やることになる。そこは1ジョブ内で `if: always() && steps.<id>.outcome == 'success'` により**失敗の伝播だけを切った**（緩い `success()` ではなく明示的な outcome 判定を使用）。

### 成否集約の担保
`always()` は `continue-on-error` を意味せず、**失敗したステップは後続が走ってもジョブを赤くする**ことを確認済み。どれか1つでも失敗すれば CI 全体が赤くなる。

ジョブ名を `check` から `frontend` / `rust` に変えたため、`gh api .../branches/main/protection` で required status check を壊さないことも確認した（ブランチは未保護）。

## docs 追従

- `CLAUDE.md`: Key Conventions の pre-commit 記述、CI/CD 節、worktree の注意
- `LINT_SETUP.md`: pre-commit の Rust ステップ（rustfmt のみ）、CI の2ジョブ構成に全面書き換え
- `docs/development.md`: Lint & Format 節、pre-commit フック節
- あわせて、docs が参照していた**存在しない `build-release.yml`** を実ファイル名 `release.yml` に修正

## 検証

`npm run lint` / `build` / `test`（62件）、`cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test`（122 unit + 16 e2e）すべて緑。`npx prettier --check` も緑。

**この PR 自体が、新しい CI 構成で走る最初の PR になる。**
